### PR TITLE
Issue #9 データ更新候補の自動Pull Requestを実装

### DIFF
--- a/.github/workflows/source-scan.yml
+++ b/.github/workflows/source-scan.yml
@@ -8,11 +8,19 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: official-source-update
+  cancel-in-progress: false
+
 jobs:
   scan:
     runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.scan.outputs.has_changes }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -20,10 +28,66 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run validate
-      - run: npm run scan -- --all --dry-run --output .cache/source-scan-result.json
+      - id: scan
+        run: |
+          npm run scan -- --all --output .cache/source-scan-result.json
+          node -e 'const result = require("./.cache/source-scan-result.json"); process.stdout.write(`has_changes=${result.status === "change_detected"}\n`)' >> "$GITHUB_OUTPUT"
       - if: always()
         uses: actions/upload-artifact@v4
         with:
           name: source-scan-result
           path: .cache/source-scan-result.json
           if-no-files-found: error
+
+  update-pr:
+    needs: scan
+    if: needs.scan.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - uses: actions/download-artifact@v4
+        with:
+          name: source-scan-result
+          path: .cache
+      - run: npm ci
+      - env:
+          UPDATE_BRANCH: automation/official-source-updates
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git ls-remote --exit-code --heads origin "$UPDATE_BRANCH"; then
+            git fetch origin "$UPDATE_BRANCH"
+            git switch --create "$UPDATE_BRANCH" --track "origin/$UPDATE_BRANCH"
+            git merge --no-edit origin/main
+          else
+            git switch --create "$UPDATE_BRANCH" origin/main
+          fi
+          npm run prepare-update -- --scan .cache/source-scan-result.json --report .cache/update-pr-body.md
+          npm test
+          npm run validate
+          if ! git diff --quiet; then
+            git add data
+            git commit -m "公式情報に基づくデータ更新候補"
+          fi
+          if git diff --quiet origin/main...HEAD; then
+            echo "No candidate difference remains against main"
+            exit 0
+          fi
+          git push --set-upstream origin "$UPDATE_BRANCH"
+          existing_pr="$(gh pr list --state open --base main --head "$UPDATE_BRANCH" --json number --jq '.[0].number')"
+          if [ -n "$existing_pr" ]; then
+            gh pr edit "$existing_pr" --body-file .cache/update-pr-body.md
+          else
+            gh pr create --base main --head "$UPDATE_BRANCH" --title "公式情報に基づくデータ更新候補" --body-file .cache/update-pr-body.md
+          fi

--- a/README.md
+++ b/README.md
@@ -68,3 +68,5 @@ npm run scan -- --all --dry-run --output .cache/source-scan-result.json
 このプロジェクトはIssue駆動で開発します。変更に着手する前に対応するIssueを確認し、Issueがなければ目的、対象範囲、受け入れ条件を記載したIssueを作成してください。Pull Requestには関連Issueを明記し、Issueの受け入れ条件に対する結果を記載します。ユーザーによるPR承認を、実装内容に対する確認として扱います。
 
 あわせて [AGENTS.md](AGENTS.md) と [PROJECT_SPEC.md](PROJECT_SPEC.md) を確認してください。新しい事実には一次情報のURLと確認日時を付け、推測値は登録しないでください。巡回先の追加・変更・停止もPull Requestでレビューします。
+
+定期巡回は既存の `source-scan.yml` だけで実行します。確定的な差分がある場合は固定ブランチ `automation/official-source-updates` から `main` 向けのPRを作成し、既存PRがあれば更新します。取得失敗、構造変更、対象不明、正本との競合ではデータをcommitせず停止します。変更がなければbranch、commit、PRを作成せず、自動マージも行いません。

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "node --test",
     "validate": "node scripts/validate/validate-data.js",
-    "scan": "node scripts/pipeline/scan-source.js"
+    "scan": "node scripts/pipeline/scan-source.js",
+    "prepare-update": "node scripts/automation/prepare-update.js"
   },
   "devDependencies": {
     "ajv": "^8.17.1",

--- a/scripts/automation/candidate-update.js
+++ b/scripts/automation/candidate-update.js
@@ -1,0 +1,160 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, extname, resolve, sep } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { parseDocument } from "yaml";
+
+function canonicalPath(root, relativePath) {
+  const dataRoot = `${resolve(root, "data")}${sep}`;
+  const path = resolve(root, relativePath);
+  if (!path.startsWith(dataRoot)) throw new Error(`Candidate target must stay under data/: ${relativePath}`);
+  return path;
+}
+
+function pathSegments(path) {
+  return path.split(".").map((segment) => /^\d+$/.test(segment) ? Number(segment) : segment);
+}
+
+function selectRecord(document, target) {
+  const records = Array.isArray(document) ? document : [document];
+  const index = records.findIndex((record) => record?.[target.record_id_field] === target.record_id);
+  if (index === -1) throw new Error(`Candidate record not found: ${target.record_id}`);
+  return { record: records[index], prefix: Array.isArray(document) ? [index] : [] };
+}
+
+function readValue(record, segments, label) {
+  let value = record;
+  for (const segment of segments) {
+    if (value === null || value === undefined || !Object.hasOwn(value, segment)) throw new Error(`Candidate path not found: ${label}`);
+    value = value[segment];
+  }
+  return value;
+}
+
+function setValue(record, segments, value) {
+  let parent = record;
+  for (const segment of segments.slice(0, -1)) parent = parent[segment];
+  parent[segments.at(-1)] = value;
+}
+
+function collectChanges(scan) {
+  if (scan?.schema_version !== 1 || !Array.isArray(scan.results)) throw new Error("Unsupported aggregate scan result");
+  if (scan.status === "error" || scan.results.some(({ status }) => status === "error")) throw new Error("Scan contains source errors; refusing candidate update");
+  if (!scan.results.every(({ status }) => ["no_change", "change_detected"].includes(status))) throw new Error("Scan contains an unsupported source status");
+
+  const changes = [];
+  for (const result of scan.results.filter(({ status }) => status === "change_detected")) {
+    if (!Array.isArray(result.fetches) || result.fetches.length === 0 || result.fetches.some(({ source_url, fetched_at, sha256 }) => !source_url || !fetched_at || !/^[a-f0-9]{64}$/.test(sha256 ?? ""))) {
+      throw new Error(`Source evidence is incomplete: ${result.source_id}`);
+    }
+    for (const difference of result.candidate_diff ?? []) {
+      if (!difference.target) throw new Error(`Candidate requires human review because it has no canonical target: ${result.source_id}/${difference.fact_id}`);
+      changes.push({ ...difference, source_id: result.source_id, fetches: result.fetches });
+    }
+  }
+  return changes;
+}
+
+export async function applyCandidateUpdates({ root, scan }) {
+  const changes = collectChanges(scan);
+  const documents = new Map();
+  const seenTargets = new Map();
+  const applied = [];
+
+  for (const change of changes) {
+    const { target } = change;
+    const key = `${target.file}:${target.record_id_field}:${target.record_id}:${target.path}`;
+    if (seenTargets.has(key) && !isDeepStrictEqual(seenTargets.get(key), change.candidate)) throw new Error(`Conflicting candidates for ${key}`);
+    seenTargets.set(key, change.candidate);
+
+    const path = canonicalPath(root, target.file);
+    if (!documents.has(path)) {
+      const source = await readFile(path, "utf8");
+      if (extname(path) === ".json") {
+        documents.set(path, { format: "json", value: JSON.parse(source) });
+      } else {
+        const yaml = parseDocument(source);
+        if (yaml.errors.length > 0) throw new Error(`${target.file}: ${yaml.errors[0].message}`);
+        documents.set(path, { format: "yaml", yaml, value: yaml.toJS() });
+      }
+    }
+
+    const document = documents.get(path);
+    const { record, prefix } = selectRecord(document.value, target);
+    const segments = pathSegments(target.path);
+    const actual = readValue(record, segments, target.path);
+    if (isDeepStrictEqual(actual, change.candidate)) continue;
+    if (!isDeepStrictEqual(actual, change.current)) throw new Error(`Canonical value changed since scan: ${key}`);
+
+    setValue(record, segments, change.candidate);
+    if (document.format === "yaml") document.yaml.setIn([...prefix, ...segments], change.candidate);
+    applied.push(change);
+  }
+
+  for (const [path, document] of documents) {
+    const content = document.format === "json" ? `${JSON.stringify(document.value, null, 2)}\n` : document.yaml.toString();
+    const temporary = `${path}.candidate-update.tmp`;
+    await writeFile(temporary, content, "utf8");
+    await rename(temporary, path);
+  }
+  return { changes, applied };
+}
+
+function display(value) {
+  return `\`${JSON.stringify(value)}\``;
+}
+
+export function buildPullRequestBody({ scan, changes }) {
+  const sourceResults = scan.results.filter(({ status }) => status === "change_detected");
+  const urls = [...new Set(sourceResults.flatMap(({ fetches }) => fetches.map(({ source_url }) => source_url)))];
+  const checkedAt = [...new Set(sourceResults.flatMap(({ fetches }) => fetches.map(({ fetched_at }) => fetched_at)))];
+  const files = [...new Set(changes.map(({ target }) => target.file))];
+  const rows = changes.map((change) => `| ${change.source_id} / ${change.fact_id} | \`${change.target.file}\` / \`${change.target.record_id}\` / \`${change.target.path}\` | ${display(change.current)} | ${display(change.candidate)} |`).join("\n");
+  return `## 概要
+
+公式一次情報の自動取得で検出した確定的な差分を、正本データの更新候補として提出します。自動マージは行いません。
+
+## 関連Issue
+
+Related to #9
+
+## 根拠
+
+${urls.map((url) => `- 公式URL: ${url}`).join("\n")}
+${checkedAt.map((time) => `- 取得・確認日時: ${time}`).join("\n")}
+
+## 変更内容
+
+| 出典 / 事実 | 対象 | 旧値 | 新値 |
+| --- | --- | --- | --- |
+${rows}
+
+## 影響範囲
+
+${files.map((file) => `- \`${file}\``).join("\n")}
+
+## 検証結果
+
+- \`npm test\`
+- \`npm run validate\`
+- 取得失敗、構造変更、対象不明、競合がないことを確認
+
+## 未解決・不確実な点
+
+なし。対象を一意に特定できない差分はこのPRへ含めず、安全停止します。
+
+## 確認事項
+
+- [x] 送信先は \`main\` である
+- [x] \`main\` へ直接pushしていない
+- [x] 公式URL、取得日時、旧値、新値を記録した
+- [x] 自動マージを設定していない
+- [ ] 人間が内容をレビューし、マージ可否を判断する
+`;
+}
+
+export async function writePullRequestBody(path, body) {
+  await mkdir(dirname(path), { recursive: true });
+  const temporary = `${path}.tmp`;
+  await writeFile(temporary, body, "utf8");
+  await rename(temporary, path);
+}

--- a/scripts/automation/prepare-update.js
+++ b/scripts/automation/prepare-update.js
@@ -1,0 +1,27 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { applyCandidateUpdates, buildPullRequestBody, writePullRequestBody } from "./candidate-update.js";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const args = process.argv.slice(2);
+const option = (name) => {
+  const index = args.indexOf(`--${name}`);
+  return index === -1 ? undefined : args[index + 1];
+};
+const scanPath = option("scan");
+const reportPath = option("report");
+
+if (!scanPath || !reportPath) {
+  console.error("Usage: node scripts/automation/prepare-update.js --scan <result.json> --report <pr-body.md>");
+  process.exitCode = 2;
+} else {
+  try {
+    const scan = JSON.parse(await readFile(scanPath, "utf8"));
+    const { changes, applied } = await applyCandidateUpdates({ root, scan });
+    await writePullRequestBody(reportPath, buildPullRequestBody({ scan, changes }));
+    console.log(JSON.stringify({ status: changes.length === 0 ? "no_change" : "prepared", detected: changes.length, applied: applied.length }));
+  } catch (error) {
+    console.error(JSON.stringify({ status: "error", error: error.message }));
+    process.exitCode = 1;
+  }
+}

--- a/tests/candidate-update.test.js
+++ b/tests/candidate-update.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parse } from "yaml";
+import { applyCandidateUpdates, buildPullRequestBody } from "../scripts/automation/candidate-update.js";
+
+const evidence = [{ source_url: "https://example.go.jp/official", fetched_at: "2026-08-17T01:02:03.000Z", sha256: "a".repeat(64) }];
+
+function scanWith(candidateDiff, status = "change_detected") {
+  return {
+    schema_version: 1,
+    status,
+    results: [{ source_id: "official-source", status, fetches: evidence, candidate_diff: candidateDiff }]
+  };
+}
+
+async function fixtureRoot() {
+  const root = await mkdtemp(join(tmpdir(), "candidate-update-"));
+  await mkdir(join(root, "data/phases"), { recursive: true });
+  await writeFile(join(root, "data/phases/sample.yaml"), "- phase_id: sample-phase\n  value:\n    numeric_value: 7.8\n", "utf8");
+  return root;
+}
+
+function difference(candidate = 7.9) {
+  return {
+    fact_id: "sample-rate",
+    target: { file: "data/phases/sample.yaml", record_id_field: "phase_id", record_id: "sample-phase", path: "value.numeric_value" },
+    current: 7.8,
+    candidate,
+    raw: "7.9 percent"
+  };
+}
+
+test("a deterministic candidate updates only its declared canonical target", async () => {
+  const root = await fixtureRoot();
+  const scan = scanWith([difference()]);
+  const result = await applyCandidateUpdates({ root, scan });
+  const document = parse(await readFile(join(root, "data/phases/sample.yaml"), "utf8"));
+  assert.equal(document[0].value.numeric_value, 7.9);
+  assert.equal(result.applied.length, 1);
+  const body = buildPullRequestBody({ scan, changes: result.changes });
+  assert.match(body, /Related to #9/);
+  assert.match(body, /https:\/\/example\.go\.jp\/official/);
+  assert.match(body, /7\.8.*7\.9/);
+});
+
+test("a repeated candidate is idempotent", async () => {
+  const root = await fixtureRoot();
+  const scan = scanWith([difference()]);
+  await applyCandidateUpdates({ root, scan });
+  const second = await applyCandidateUpdates({ root, scan });
+  assert.equal(second.applied.length, 0);
+});
+
+test("source errors, untargeted changes, and stale canonical values stop safely", async () => {
+  const root = await fixtureRoot();
+  await assert.rejects(applyCandidateUpdates({ root, scan: { schema_version: 1, status: "error", results: [{ source_id: "bad", status: "error" }] } }), /source errors/);
+  await assert.rejects(applyCandidateUpdates({ root, scan: scanWith([{ ...difference(), target: null }]) }), /human review/);
+  await writeFile(join(root, "data/phases/sample.yaml"), "- phase_id: sample-phase\n  value:\n    numeric_value: 8.1\n", "utf8");
+  await assert.rejects(applyCandidateUpdates({ root, scan: scanWith([difference()]) }), /changed since scan/);
+});
+
+test("conflicting duplicate targets are rejected before writing", async () => {
+  const root = await fixtureRoot();
+  await assert.rejects(applyCandidateUpdates({ root, scan: scanWith([difference(7.9), difference(8.0)]) }), /Conflicting candidates/);
+  const document = parse(await readFile(join(root, "data/phases/sample.yaml"), "utf8"));
+  assert.equal(document[0].value.numeric_value, 7.8);
+});

--- a/tests/repository-validator.test.js
+++ b/tests/repository-validator.test.js
@@ -27,11 +27,19 @@ test("source scan workflow is fixed, scheduled, and manually runnable", async ()
   assert.ok(Object.hasOwn(workflow.on, "schedule"));
   assert.ok(!Object.hasOwn(workflow.on, "push"));
   assert.equal(workflow.permissions.contents, "read");
-  const commands = workflow.jobs.scan.steps.map(({ run }) => run).filter(Boolean);
-  assert.ok(commands.includes("npm test"));
-  assert.ok(commands.includes("npm run validate"));
-  assert.ok(commands.some((command) => command.includes("--dry-run")));
-  assert.ok(commands.some((command) => command.includes("--all")));
+  assert.equal(workflow.jobs["update-pr"].permissions.contents, "write");
+  assert.equal(workflow.jobs["update-pr"].permissions["pull-requests"], "write");
+  assert.equal(workflow.jobs["update-pr"].needs, "scan");
+  assert.equal(workflow.concurrency.group, "official-source-update");
+  assert.equal(workflow.concurrency["cancel-in-progress"], false);
+  const scanCommands = workflow.jobs.scan.steps.map(({ run }) => run).filter(Boolean);
+  const updateCommands = workflow.jobs["update-pr"].steps.map(({ run }) => run).filter(Boolean);
+  assert.ok(scanCommands.includes("npm test"));
+  assert.ok(scanCommands.includes("npm run validate"));
+  assert.ok(scanCommands.some((command) => command.includes("--all")));
+  assert.ok(updateCommands.some((command) => command.includes("npm run prepare-update")));
+  assert.ok(updateCommands.some((command) => command.includes("gh pr list") && command.includes("gh pr edit") && command.includes("gh pr create")));
+  assert.ok([...scanCommands, ...updateCommands].every((command) => !command.includes("gh pr merge")));
 });
 
 test("revenue schema distinguishes an unavailable amount from zero", async () => {


### PR DESCRIPTION
## 概要

Closes #9

公式情報の差分候補を安全に正本へ適用し、固定ブランチから `main` 向けPull Requestを作成または更新する処理を実装しました。既存の `source-scan.yml` を拡張しているため、税目や出典が増えてもWorkflowファイルは増えません。

## 受け入れ条件

- [x] 変更なしではbranch、commit、PRを作成しない
- [x] 変更ありでは固定ブランチ `automation/official-source-updates` からPRを作成または更新する
- [x] `main`への直接push経路がない
- [x] PR本文へ関連Issue、取得日時、公式URL、旧値、新値、影響範囲、検証結果、不確実な点を出力する
- [x] 同じ固定ブランチの既存PRを検索し、重複PRを作成しない
- [x] 取得失敗、構造変更、対象不明、正本値の競合、検証失敗ではcommit・pushしない
- [x] 自動マージ処理がない
- [x] 巡回jobは `contents: read`、更新jobだけ `contents: write` と `pull-requests: write`
- [x] 同時実行制御とオフラインテストを追加した

## 作業・検証の分担

- 主担当: Codex
- 調査・検証担当: 主担当がIssue範囲、権限、Workflow、テストを一貫して確認
- 独立検証の結果: 通常Issueのため追加エージェントは使用せず、単体・構造・実巡回で検証

## 根拠

- 公式URL: https://laws.e-gov.go.jp/api/2/law_data/363AC0000000108
- 公式URL: https://laws.e-gov.go.jp/api/2/law_data/325AC0000000226
- 公式URL: https://www.nta.go.jp/taxes/shiraberu/taxanswer/shohi/6101.htm
- 公式URL: https://www.nta.go.jp/taxes/shiraberu/taxanswer/shohi/6102.htm
- 確認日時: 2026-08-17T13:13:25Z

## データへの影響

- 対象ID: なし（実装時の公式情報巡回は `no_change`）
- 旧値: 変更なし
- 新値: 変更なし
- 影響範囲: 将来の確定的な差分だけを、設定済みtargetへ反映する

## 安全設計

- aggregate scanに1件でもエラーがあれば更新を拒否
- canonical targetのない差分は、人間確認が必要として停止
- scan時の旧値とbranch上の正本値が一致しなければ競合として停止
- 同じtargetに異なる候補があれば、書き込み前に停止
- 正本データのテストとSchema検証が成功してからcommit・push
- PR作成後も人間のレビューとマージ判断を必須とし、自動マージしない

## 検証

- `npm ci`: 成功、脆弱性0件
- `npm test`: 28件成功
- `npm run validate`: 成功
- `npm run scan -- --all --dry-run --output .cache/issue-9-live-scan.json`: 成功、`no_change`
- `git diff --check`: 成功

## 未解決・不確実な点

- 対象を一意に特定できない公式差分は自動PRへ含めず、安全停止します。Phase 4（#8）のIssue化フローは別Issueの対象です。
- 実際のbranch・PR作成経路は、このPRを `main` へマージした後のGitHub Actions実行で初めて稼働します。

## 確認事項

- [x] 対応するIssueの範囲内の変更である
- [x] PRの送信先は `main` である
- [x] 推測値を確定値として記録していない
- [x] `npm test` と `npm run validate` を実行した
- [x] エージェントはマージせず、人間のレビューとマージ判断を待つ
