### PR TITLE
Issue #8 監査・品質検証と不確実事項のIssue化を実装

### DIFF
--- a/.github/workflows/source-scan.yml
+++ b/.github/workflows/source-scan.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       has_changes: ${{ steps.scan.outputs.has_changes }}
+      has_findings: ${{ steps.scan.outputs.has_findings }}
+      scan_failed: ${{ steps.scan.outputs.scan_failed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -28,16 +30,27 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run validate
+      - run: npm run audit -- --output .cache/repository-audit.json
       - id: scan
         run: |
+          set +e
           npm run scan -- --all --output .cache/source-scan-result.json
-          node -e 'const result = require("./.cache/source-scan-result.json"); process.stdout.write(`has_changes=${result.status === "change_detected"}\n`)' >> "$GITHUB_OUTPUT"
+          scan_exit=$?
+          set -e
+          npm run audit:scan -- --scan .cache/source-scan-result.json --report .cache/source-audit-report.json
+          node -e 'const scan = require("./.cache/source-scan-result.json"); const audit = require("./.cache/source-audit-report.json"); process.stdout.write(`has_changes=${scan.status === "change_detected"}\nhas_findings=${audit.issue_candidates.length > 0}\nscan_failed=${scan.status === "error"}\n`)' >> "$GITHUB_OUTPUT"
+          echo "scan_exit=$scan_exit"
       - if: always()
         uses: actions/upload-artifact@v4
         with:
           name: source-scan-result
-          path: .cache/source-scan-result.json
+          path: |
+            .cache/source-scan-result.json
+            .cache/source-audit-report.json
+            .cache/repository-audit.json
           if-no-files-found: error
+      - if: steps.scan.outputs.scan_failed == 'true'
+        run: exit 1
 
   update-pr:
     needs: scan
@@ -76,6 +89,7 @@ jobs:
           npm run prepare-update -- --scan .cache/source-scan-result.json --report .cache/update-pr-body.md
           npm test
           npm run validate
+          npm run audit -- --output .cache/repository-audit-after-update.json
           if ! git diff --quiet; then
             git add data
             git commit -m "公式情報に基づくデータ更新候補"
@@ -91,3 +105,25 @@ jobs:
           else
             gh pr create --base main --head "$UPDATE_BRANCH" --title "公式情報に基づくデータ更新候補" --body-file .cache/update-pr-body.md
           fi
+
+  audit-issues:
+    needs: scan
+    if: always() && needs.scan.outputs.has_findings == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: actions/download-artifact@v4
+        with:
+          name: source-scan-result
+          path: .cache
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: npm run audit:issues -- --report .cache/source-audit-report.json

--- a/README.md
+++ b/README.md
@@ -70,3 +70,5 @@ npm run scan -- --all --dry-run --output .cache/source-scan-result.json
 あわせて [AGENTS.md](AGENTS.md) と [PROJECT_SPEC.md](PROJECT_SPEC.md) を確認してください。新しい事実には一次情報のURLと確認日時を付け、推測値は登録しないでください。巡回先の追加・変更・停止もPull Requestでレビューします。
 
 定期巡回は既存の `source-scan.yml` だけで実行します。確定的な差分がある場合は固定ブランチ `automation/official-source-updates` から `main` 向けのPRを作成し、既存PRがあれば更新します。取得失敗、構造変更、対象不明、正本との競合ではデータをcommitせず停止します。変更がなければbranch、commit、PRを作成せず、自動マージも行いません。
+
+監査は `npm run audit -- --output .cache/repository-audit.json` で実行できます。制度日付、主状態と法律手続状態、phase期間、参照関係、金額の集計範囲を検査し、再生成可能なJSONレポートを `.cache/` に出力します。定期巡回で一時障害の再試行後も取得できない場合、参照元の構造が変わった場合、公式ソース間で値が一致しない場合、または正本へ対応付けられない場合は、正本を推測更新せず `[audit-topic:...]` を持つIssueを作成します。同じキーの未解決Issueは再利用し、解決後もIssueを削除せず根拠と関連PRを残してCloseします。

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "test": "node --test",
     "validate": "node scripts/validate/validate-data.js",
     "scan": "node scripts/pipeline/scan-source.js",
-    "prepare-update": "node scripts/automation/prepare-update.js"
+    "prepare-update": "node scripts/automation/prepare-update.js",
+    "audit": "node scripts/audit/audit-repository.js",
+    "audit:scan": "node scripts/audit/audit-source-scan.js",
+    "audit:issues": "node scripts/audit/publish-audit-issues.js"
   },
   "devDependencies": {
     "ajv": "^8.17.1",

--- a/schemas/change.schema.json
+++ b/schemas/change.schema.json
@@ -4,7 +4,7 @@
   "title": "Burden change",
   "type": "object",
   "additionalProperties": false,
-  "required": ["change_id", "tax_ids", "title", "change_types", "proposal_origin", "current_stage", "stage_confidence", "bill_ids", "law_ids", "events", "application_start_dates", "collection_start_dates", "source_refs", "evidence_gaps"],
+  "required": ["change_id", "tax_ids", "title", "change_types", "proposal_origin", "current_stage", "stage_confidence", "bill_ids", "law_ids", "events", "promulgation_date", "enforcement_date", "application_start_dates", "collection_start_dates", "source_refs", "evidence_gaps"],
   "properties": {
     "change_id": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
     "tax_ids": {"type": "array", "minItems": 1, "items": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"}, "uniqueItems": true},

--- a/scripts/audit/audit-repository.js
+++ b/scripts/audit/audit-repository.js
@@ -1,0 +1,41 @@
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { validateRepository } from "../validate/repository-validator.js";
+import { auditRepositoryCollections } from "./repository-audit.js";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const args = process.argv.slice(2);
+const option = (name) => {
+  const index = args.indexOf(`--${name}`);
+  return index === -1 ? undefined : args[index + 1];
+};
+const output = option("output");
+const asOf = option("as-of") ?? new Date().toISOString().slice(0, 10);
+
+try {
+  const { errors, collections } = await validateRepository(root);
+  const findings = [
+    ...errors.map((message) => ({ severity: "error", code: "schema_or_integrity_error", record_id: null, message })),
+    ...auditRepositoryCollections(collections, { asOf })
+  ];
+  const report = {
+    schema_version: 1,
+    status: findings.some(({ severity }) => severity === "error") ? "error" : findings.length > 0 ? "warning" : "clean",
+    generated_at: new Date().toISOString(),
+    as_of: asOf,
+    summary: { errors: findings.filter(({ severity }) => severity === "error").length, warnings: findings.filter(({ severity }) => severity === "warning").length },
+    findings
+  };
+  if (output) {
+    await mkdir(dirname(output), { recursive: true });
+    const temporary = `${output}.tmp`;
+    await writeFile(temporary, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+    await rename(temporary, output);
+  }
+  console.log(JSON.stringify(report));
+  if (report.status === "error") process.exitCode = 1;
+} catch (error) {
+  console.error(JSON.stringify({ status: "error", error: error.message }));
+  process.exitCode = 1;
+}

--- a/scripts/audit/audit-source-scan.js
+++ b/scripts/audit/audit-source-scan.js
@@ -1,0 +1,30 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { auditSourceScan, issueCandidatesFromAudit } from "./source-scan-audit.js";
+
+const args = process.argv.slice(2);
+const option = (name) => {
+  const index = args.indexOf(`--${name}`);
+  return index === -1 ? undefined : args[index + 1];
+};
+const scanPath = option("scan");
+const reportPath = option("report");
+
+if (!scanPath || !reportPath) {
+  console.error("Usage: node scripts/audit/audit-source-scan.js --scan <scan.json> --report <audit.json>");
+  process.exitCode = 2;
+} else {
+  try {
+    const scan = JSON.parse(await readFile(scanPath, "utf8"));
+    const report = auditSourceScan(scan);
+    report.issue_candidates = issueCandidatesFromAudit(report);
+    await mkdir(dirname(reportPath), { recursive: true });
+    const temporary = `${reportPath}.tmp`;
+    await writeFile(temporary, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+    await rename(temporary, reportPath);
+    console.log(JSON.stringify({ status: report.status, findings: report.findings.length }));
+  } catch (error) {
+    console.error(JSON.stringify({ status: "error", error: error.message }));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/audit/publish-audit-issues.js
+++ b/scripts/audit/publish-audit-issues.js
@@ -1,0 +1,76 @@
+import { readFile } from "node:fs/promises";
+
+const args = process.argv.slice(2);
+const option = (name) => {
+  const index = args.indexOf(`--${name}`);
+  return index === -1 ? undefined : args[index + 1];
+};
+
+function githubClient({ repository, token, fetchImpl = globalThis.fetch }) {
+  const request = async (path, init = {}) => {
+    const response = await fetchImpl(`https://api.github.com${path}`, {
+      ...init,
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+        ...init.headers
+      }
+    });
+    if (!response.ok) throw new Error(`GitHub API failed (${response.status}): ${await response.text()}`);
+    return response.json();
+  };
+  return {
+    async findOpen(marker) {
+      const query = encodeURIComponent(`repo:${repository} is:issue is:open "${marker}" in:body`);
+      const result = await request(`/search/issues?q=${query}&per_page=1`);
+      return result.items?.[0] ?? null;
+    },
+    async create(candidate) {
+      return request(`/repos/${repository}/issues`, { method: "POST", body: JSON.stringify({ title: candidate.title, body: candidate.body }) });
+    },
+    async comment(issueNumber, candidate) {
+      return request(`/repos/${repository}/issues/${issueNumber}/comments`, {
+        method: "POST",
+        body: JSON.stringify({ body: `## 自動監査による再検知\n\n同じ重複判定キーの事象を再検知しました。過去の記録を削除せず、今回の監査結果を追記します。\n\n${candidate.body}` })
+      });
+    }
+  };
+}
+
+export async function publishAuditIssues({ candidates, findOpen, create, comment = async () => {} }) {
+  const results = [];
+  for (const candidate of candidates) {
+    const existing = await findOpen(candidate.marker);
+    if (existing) {
+      await comment(existing.number, candidate);
+      results.push({ topic_key: candidate.topic_key, status: "updated", number: existing.number, url: existing.html_url });
+    }
+    else {
+      const created = await create(candidate);
+      results.push({ topic_key: candidate.topic_key, status: "created", number: created.number, url: created.html_url });
+    }
+  }
+  return results;
+}
+
+const reportPath = option("report");
+if (process.argv[1]?.endsWith("publish-audit-issues.js")) {
+  if (!reportPath) {
+    console.error("Usage: node scripts/audit/publish-audit-issues.js --report <audit.json>");
+    process.exitCode = 2;
+  } else {
+    try {
+      const report = JSON.parse(await readFile(reportPath, "utf8"));
+      const repository = process.env.GITHUB_REPOSITORY;
+      const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+      if (!repository || !token) throw new Error("GITHUB_REPOSITORY and GH_TOKEN are required");
+      const client = githubClient({ repository, token });
+      const results = await publishAuditIssues({ candidates: report.issue_candidates ?? [], findOpen: client.findOpen, create: client.create, comment: client.comment });
+      console.log(JSON.stringify({ status: "complete", results }));
+    } catch (error) {
+      console.error(JSON.stringify({ status: "error", error: error.message }));
+      process.exitCode = 1;
+    }
+  }
+}

--- a/scripts/audit/repository-audit.js
+++ b/scripts/audit/repository-audit.js
@@ -1,0 +1,118 @@
+import { deriveBurdenStatus } from "../normalize/derive-status.js";
+
+function add(findings, severity, code, recordId, message) {
+  findings.push({ severity, code, record_id: recordId, message });
+}
+
+function knownDate(evidencedDate) {
+  return evidencedDate?.date_value ?? null;
+}
+
+function rangesOverlap(left, right) {
+  if (!left.application_start || !right.application_start) return false;
+  const leftEnd = left.application_end ?? "9999-12-31";
+  const rightEnd = right.application_end ?? "9999-12-31";
+  return left.application_start <= rightEnd && right.application_start <= leftEnd;
+}
+
+function nextDay(date) {
+  const value = new Date(`${date}T00:00:00Z`);
+  value.setUTCDate(value.getUTCDate() + 1);
+  return value.toISOString().slice(0, 10);
+}
+
+export function auditRepositoryCollections(collections, { asOf = new Date().toISOString().slice(0, 10) } = {}) {
+  const findings = [];
+  const changes = new Map((collections.changes ?? []).map((record) => [record.change_id, record]));
+  const events = new Map((collections.events ?? []).map((record) => [record.event_id, record]));
+  const phases = new Map((collections.phases ?? []).map((record) => [record.phase_id, record]));
+  const registeredOrigins = new Set((collections.sources ?? []).map(({ base_url }) => {
+    try { return new URL(base_url).origin; } catch { return null; }
+  }).filter(Boolean));
+  const burdenLawIds = new Set((collections.burdens ?? []).flatMap(({ legal_bases }) => (legal_bases ?? []).map(({ law_id }) => law_id).filter(Boolean)));
+
+  const auditSourceUrl = (url, recordId) => {
+    if (registeredOrigins.size === 0 || !url) return;
+    let origin;
+    try { origin = new URL(url).origin; } catch { return; }
+    if (!registeredOrigins.has(origin)) add(findings, "warning", "unregistered_source_origin", recordId, `${origin} is not represented in config/sources.yaml`);
+  };
+
+  for (const change of collections.changes ?? []) {
+    const orderedDates = [
+      ["promulgation_date", knownDate(change.promulgation_date)],
+      ["enforcement_date", knownDate(change.enforcement_date)],
+      ["application_start_date", (change.application_start_dates ?? []).map(knownDate).filter(Boolean).sort()[0] ?? null],
+      ["collection_start_date", (change.collection_start_dates ?? []).map(knownDate).filter(Boolean).sort()[0] ?? null]
+    ];
+    for (let leftIndex = 0; leftIndex < orderedDates.length; leftIndex += 1) {
+      for (let rightIndex = leftIndex + 1; rightIndex < orderedDates.length; rightIndex += 1) {
+        const [previousName, previous] = orderedDates[leftIndex];
+        const [currentName, current] = orderedDates[rightIndex];
+        if (previous && current && previous > current) add(findings, "warning", "date_order_requires_review", change.change_id, `${previousName} ${previous} is after ${currentName} ${current}`);
+      }
+    }
+    for (const lawId of change.law_ids ?? []) {
+      if (!burdenLawIds.has(lawId)) add(findings, "warning", "unlinked_law_id", change.change_id, `${lawId} is not present in the related burden legal_bases`);
+    }
+    for (const eventId of change.events ?? []) {
+      const event = events.get(eventId);
+      if (event && event.change_id !== change.change_id) add(findings, "error", "event_change_mismatch", change.change_id, `${eventId} points to ${event.change_id}`);
+    }
+  }
+
+  for (const phase of collections.phases ?? []) {
+    const change = changes.get(phase.change_id);
+    if (change && !change.tax_ids.includes(phase.tax_id)) add(findings, "error", "phase_change_tax_mismatch", phase.phase_id, `${phase.tax_id} is not included in ${phase.change_id}.tax_ids`);
+    if (phase.application_start && phase.collection_start && phase.collection_start < phase.application_start) add(findings, "warning", "collection_before_application", phase.phase_id, `${phase.collection_start} is before ${phase.application_start}`);
+    if (phase.value?.kind === "rate" && phase.value.unit !== "percent") add(findings, "error", "rate_unit_mismatch", phase.phase_id, `rate value uses ${phase.value.unit}`);
+  }
+
+  const phaseGroups = new Map();
+  for (const phase of collections.phases ?? []) {
+    const key = `${phase.tax_id}|${phase.subject_scope}`;
+    if (!phaseGroups.has(key)) phaseGroups.set(key, []);
+    phaseGroups.get(key).push(phase);
+  }
+  for (const [key, group] of phaseGroups) {
+    const ordered = group.filter(({ application_start }) => application_start).sort((a, b) => a.application_start.localeCompare(b.application_start));
+    for (let index = 1; index < ordered.length; index += 1) {
+      const previous = ordered[index - 1];
+      const current = ordered[index];
+      if (rangesOverlap(previous, current)) add(findings, "warning", "phase_period_overlap", key, `${previous.phase_id} overlaps ${current.phase_id}`);
+      else if (previous.application_end && nextDay(previous.application_end) < current.application_start) add(findings, "warning", "phase_period_gap", key, `${previous.phase_id} and ${current.phase_id} have an uncovered period`);
+    }
+  }
+
+  for (const burden of collections.burdens ?? []) {
+    for (const legalBase of burden.legal_bases ?? []) auditSourceUrl(legalBase.source_url, burden.tax_id);
+    const currentPhases = (burden.current_phases ?? []).map((id) => phases.get(id)).filter(Boolean);
+    for (const phase of currentPhases) {
+      if (phase.tax_id !== burden.tax_id) add(findings, "error", "burden_phase_tax_mismatch", burden.tax_id, `${phase.phase_id} belongs to ${phase.tax_id}`);
+    }
+    for (const changeId of burden.pending_changes ?? []) {
+      const change = changes.get(changeId);
+      if (change && !change.tax_ids.includes(burden.tax_id)) add(findings, "error", "burden_pending_change_mismatch", burden.tax_id, `${changeId} does not include ${burden.tax_id}`);
+    }
+    if (currentPhases.length > 0) {
+      const derived = deriveBurdenStatus(currentPhases, asOf);
+      const expected = burden.pending_changes?.length > 0 && derived === "active" ? "active_with_pending_change" : derived;
+      if (burden.current_status !== expected) add(findings, "error", "burden_status_mismatch", burden.tax_id, `stored=${burden.current_status}, derived=${expected}`);
+    }
+    if (burden.current_status === "active_with_pending_change" && burden.pending_changes.length === 0) add(findings, "error", "missing_pending_change", burden.tax_id, "active_with_pending_change requires pending_changes");
+  }
+
+  const revenueKeys = new Map();
+  for (const revenue of collections.revenues ?? []) {
+    auditSourceUrl(revenue.source_url, revenue.record_id);
+    if (["included_in_parent_total", "partial"].includes(revenue.value_status) && !revenue.evidence_gap_reason) add(findings, "error", "amount_scope_reason_missing", revenue.record_id, `${revenue.value_status} requires evidence_gap_reason`);
+    if (revenue.period_start && revenue.fiscal_year && !revenue.period_start.startsWith(revenue.fiscal_year)) add(findings, "warning", "fiscal_period_mismatch", revenue.record_id, `${revenue.period_start} does not start in fiscal year ${revenue.fiscal_year}`);
+    const key = [revenue.tax_id, revenue.period_start, revenue.period_end, revenue.amount_yen, revenue.accounting_basis, revenue.consolidation_scope].join("|");
+    if (revenue.value_status === "available" && revenueKeys.has(key)) add(findings, "warning", "possible_amount_double_count", revenue.record_id, `same amount and aggregation scope as ${revenueKeys.get(key)}`);
+    else if (revenue.value_status === "available") revenueKeys.set(key, revenue.record_id);
+  }
+
+  for (const event of collections.events ?? []) auditSourceUrl(event.source_url, event.event_id);
+
+  return findings;
+}

--- a/scripts/audit/source-scan-audit.js
+++ b/scripts/audit/source-scan-audit.js
@@ -1,0 +1,153 @@
+import { createHash } from "node:crypto";
+
+function topicKey(parts) {
+  const identity = parts.map((part) => String(part ?? "unknown").trim().toLowerCase()).join("|");
+  return `audit-${createHash("sha256").update(identity).digest("hex").slice(0, 20)}`;
+}
+
+function evidenceUrls(result) {
+  return [...new Set([
+    result.source_url,
+    ...(result.fetches ?? []).map(({ source_url }) => source_url)
+  ].filter(Boolean))];
+}
+
+function targetIdentity(difference) {
+  const target = difference.target;
+  return target ? `${target.record_id_field}:${target.record_id}:${target.path}` : difference.fact_id;
+}
+
+function finding({ code, sourceId, summary, details, urls, detectedAt, difference }) {
+  const target = difference?.target ?? null;
+  return {
+    severity: "needs_review",
+    code,
+    topic_key: topicKey([sourceId, code, difference ? targetIdentity(difference) : "source-level"]),
+    source_id: sourceId,
+    tax_id: target?.record_id_field === "tax_id" ? target.record_id : null,
+    change_id: target?.record_id_field === "change_id" ? target.record_id : null,
+    target,
+    summary,
+    details,
+    source_urls: urls,
+    detected_at: detectedAt
+  };
+}
+
+export function auditSourceScan(scan) {
+  if (scan?.schema_version !== 1 || !Array.isArray(scan.results)) throw new Error("Unsupported aggregate scan result");
+  const detectedAt = scan.completed_at ?? new Date().toISOString();
+  const findings = [];
+
+  for (const result of scan.results) {
+    const urls = evidenceUrls(result);
+    if (result.status === "error") {
+      findings.push(finding({
+        code: result.error_code ?? "source_processing_failed",
+        sourceId: result.source_id,
+        summary: `${result.source_id} の自動確認に失敗`,
+        details: result.error ?? "原因不明の取得・処理失敗",
+        urls,
+        detectedAt
+      }));
+      continue;
+    }
+    for (const difference of result.candidate_diff ?? []) {
+      if (!difference.target) {
+        findings.push(finding({
+          code: "unmapped_official_change",
+          sourceId: result.source_id,
+          summary: `${result.source_id} で正本へ自動対応できない公式差分を検出`,
+          details: `${difference.fact_id}: ${JSON.stringify(difference.current)} → ${JSON.stringify(difference.candidate)}`,
+          urls,
+          detectedAt,
+          difference
+        }));
+      }
+    }
+  }
+
+  const targetValues = new Map();
+  for (const result of scan.results.filter(({ status }) => status === "change_detected")) {
+    for (const difference of result.candidate_diff ?? []) {
+      if (!difference.target) continue;
+      const key = `${difference.target.file}:${difference.target.record_id}:${difference.target.path}`;
+      const serialized = JSON.stringify(difference.candidate);
+      if (targetValues.has(key) && targetValues.get(key).serialized !== serialized) {
+        const previous = targetValues.get(key);
+        findings.push(finding({
+          code: "official_source_disagreement",
+          sourceId: [previous.sourceId, result.source_id].sort().join("+"),
+          summary: "公式ソース間で更新候補が一致しない",
+          details: `${key}: ${previous.serialized} / ${serialized}`,
+          urls: [...new Set([...previous.urls, ...evidenceUrls(result)])],
+          detectedAt,
+          difference
+        }));
+      } else {
+        targetValues.set(key, { serialized, sourceId: result.source_id, urls: evidenceUrls(result) });
+      }
+    }
+  }
+
+  return {
+    schema_version: 1,
+    status: findings.length === 0 ? "clean" : "needs_review",
+    generated_at: detectedAt,
+    scan_status: scan.status,
+    reproducibility: scan.results.flatMap((result) => (result.fetches ?? []).map(({ source_url, fetched_at, sha256 }) => ({ source_id: result.source_id, source_url, fetched_at, sha256 }))),
+    summary: {
+      sources_checked: scan.results.length,
+      findings: findings.length,
+      transient_failures: findings.filter(({ code }) => code === "url_transient_failure").length,
+      structure_changes: findings.filter(({ code }) => code === "source_structure_changed").length,
+      source_disagreements: findings.filter(({ code }) => code === "official_source_disagreement").length
+    },
+    findings
+  };
+}
+
+export function issueCandidateForFinding(finding) {
+  const marker = `[audit-topic:${finding.topic_key}]`;
+  const safeText = (value) => String(value).replaceAll("@", "@\u200b").replaceAll("<!--", "&lt;!--");
+  const urls = finding.source_urls.length > 0 ? finding.source_urls.map((url) => `- ${url}`).join("\n") : "- 取得前または取得中に失敗したため確認可能なURLなし";
+  return {
+    topic_key: finding.topic_key,
+    marker,
+    title: `[要確認] ${safeText(finding.summary)}`.slice(0, 200),
+    body: `## 概要
+
+自動監査が、推測によるデータ更新を禁止すべき事象を検出しました。正本データは変更していません。
+
+## 監査結果
+
+- 種別: \`${finding.code}\`
+- source_id: \`${finding.source_id}\`
+- tax_id: ${finding.tax_id ? `\`${finding.tax_id}\`` : "unknown"}
+- change_id: ${finding.change_id ? `\`${finding.change_id}\`` : "unknown"}
+- 検出日時: ${finding.detected_at}
+- 詳細: ${safeText(finding.details)}
+
+## 一次情報
+
+${urls}
+
+## 重複判定キー
+
+${marker}
+
+## 対応方針
+
+- 一時障害の場合は再取得結果を追記する
+- 構造変更またはソース不一致の場合は人間が公式情報を確認する
+- 公式根拠が確定するまで正本を推測更新しない
+- 成立・解決確認後もIssueを削除せず、根拠と関連PRを追記してCloseする
+
+Related to #8
+`
+  };
+}
+
+export function issueCandidatesFromAudit(report) {
+  return report.findings.map(issueCandidateForFinding);
+}

--- a/scripts/fetch/http-fetcher.js
+++ b/scripts/fetch/http-fetcher.js
@@ -1,23 +1,66 @@
 import { createHash } from "node:crypto";
 
-export async function fetchSourcePages(source, { fetchImpl = globalThis.fetch, now = () => new Date(), timeoutMs = 30000 } = {}) {
+const TRANSIENT_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+export class SourceFetchError extends Error {
+  constructor(message, { code, sourceUrl, retryable = false, attempts = 1, cause } = {}) {
+    super(message, { cause });
+    this.name = "SourceFetchError";
+    this.code = code;
+    this.sourceUrl = sourceUrl;
+    this.retryable = retryable;
+    this.attempts = attempts;
+  }
+}
+
+async function fetchWithRetry(sourceUrl, options, { fetchImpl, retryAttempts, sleep, timeoutMs }) {
+  let lastError;
+  for (let attempt = 1; attempt <= retryAttempts; attempt += 1) {
+    try {
+      const response = await fetchImpl(sourceUrl, { ...options, signal: AbortSignal.timeout(timeoutMs) });
+      if (response.ok) return response;
+      const retryable = TRANSIENT_STATUSES.has(response.status);
+      lastError = new SourceFetchError(`Fetch failed (${response.status}) for ${sourceUrl}`, {
+        code: retryable ? "url_transient_failure" : "url_permanent_failure",
+        sourceUrl,
+        retryable,
+        attempts: attempt
+      });
+      if (!retryable) throw lastError;
+    } catch (error) {
+      if (error instanceof SourceFetchError && !error.retryable) throw error;
+      lastError = error instanceof SourceFetchError ? error : new SourceFetchError(`Fetch failed for ${sourceUrl}: ${error.message}`, {
+        code: "url_transient_failure", sourceUrl, retryable: true, attempts: attempt, cause: error
+      });
+    }
+    if (attempt < retryAttempts) await sleep(250 * (2 ** (attempt - 1)));
+  }
+  throw new SourceFetchError(`${lastError.message} after ${retryAttempts} attempts`, {
+    code: lastError.code, sourceUrl, retryable: lastError.retryable, attempts: retryAttempts, cause: lastError
+  });
+}
+
+export async function fetchSourcePages(source, { fetchImpl = globalThis.fetch, now = () => new Date(), timeoutMs = 30000, retryAttempts = 3, sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)) } = {}) {
   const pages = [];
   for (const sourceUrl of source.entry_urls) {
-    const response = await fetchImpl(sourceUrl, {
-      headers: { "user-agent": "japan-tax-and-public-burden/0.1 (+https://github.com/pirosiki1144/japan-tax-and-public-burden)" },
-      signal: AbortSignal.timeout(timeoutMs)
-    });
-    if (!response.ok) throw new Error(`Fetch failed (${response.status}) for ${sourceUrl}`);
+    const response = await fetchWithRetry(sourceUrl, {
+      headers: { "user-agent": "japan-tax-and-public-burden/0.1 (+https://github.com/pirosiki1144/japan-tax-and-public-burden)" }
+    }, { fetchImpl, retryAttempts, sleep, timeoutMs });
     const finalUrl = response.url || sourceUrl;
-    if (new URL(finalUrl).origin !== new URL(source.base_url).origin) throw new Error(`Unexpected redirect origin for ${sourceUrl}: ${finalUrl}`);
+    if (new URL(finalUrl).origin !== new URL(source.base_url).origin) throw new SourceFetchError(`Unexpected redirect origin for ${sourceUrl}: ${finalUrl}`, { code: "url_unexpected_redirect", sourceUrl });
     const contentType = response.headers.get("content-type") ?? "";
     const acceptedContentTypes = source.accepted_content_types ?? ["text/html"];
     if (!acceptedContentTypes.some((accepted) => contentType.toLowerCase().includes(accepted.toLowerCase()))) {
-      throw new Error(`Unexpected content type for ${sourceUrl}: ${contentType || "missing"}`);
+      throw new SourceFetchError(`Unexpected content type for ${sourceUrl}: ${contentType || "missing"}`, { code: "source_structure_changed", sourceUrl });
     }
     const bytes = new Uint8Array(await response.arrayBuffer());
-    if (bytes.length === 0) throw new Error(`Empty response for ${sourceUrl}`);
-    const body = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    if (bytes.length === 0) throw new SourceFetchError(`Empty response for ${sourceUrl}`, { code: "source_structure_changed", sourceUrl });
+    let body;
+    try {
+      body = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    } catch (error) {
+      throw new SourceFetchError(`Response is not valid UTF-8 for ${sourceUrl}`, { code: "source_structure_changed", sourceUrl, cause: error });
+    }
     pages.push({
       source_url: sourceUrl,
       final_url: finalUrl,

--- a/scripts/pipeline/source-pipeline.js
+++ b/scripts/pipeline/source-pipeline.js
@@ -8,18 +8,25 @@ export async function runSourcePipeline({ root, sourceId, source: configuredSour
   const source = configuredSource ?? await loadEnabledSource(root, sourceId);
   const adapter = getSourceAdapter(source.adapter);
   const pages = await fetchSourcePages(source, { fetchImpl, now });
-  const normalized = validateNormalizedSource(adapter.normalize(source, pages));
-  const candidateDiff = await detectCanonicalDiff(root, normalized);
-  return {
-    schema_version: 1,
-    status: candidateDiff.length === 0 ? "no_change" : "change_detected",
-    dry_run: dryRun,
-    source_id: source.source_id,
-    completed_at: now().toISOString(),
-    fetches: pages.map(({ body: _body, ...metadata }) => metadata),
-    normalized,
-    candidate_diff: candidateDiff
-  };
+  const fetches = pages.map(({ body: _body, ...metadata }) => metadata);
+  try {
+    const normalized = validateNormalizedSource(adapter.normalize(source, pages));
+    const candidateDiff = await detectCanonicalDiff(root, normalized);
+    return {
+      schema_version: 1,
+      status: candidateDiff.length === 0 ? "no_change" : "change_detected",
+      dry_run: dryRun,
+      source_id: source.source_id,
+      completed_at: now().toISOString(),
+      fetches,
+      normalized,
+      candidate_diff: candidateDiff
+    };
+  } catch (error) {
+    error.fetches = fetches;
+    error.sourceUrl ??= source.entry_urls[0];
+    throw error;
+  }
 }
 
 export async function runAutomatedSources({ root, fetchImpl, now = () => new Date(), dryRun = false }) {
@@ -34,7 +41,18 @@ export async function runConfiguredSources({ root, sources, fetchImpl, now = () 
     try {
       results.push(await runSourcePipeline({ root, sourceId: source.source_id, source, fetchImpl, now, dryRun }));
     } catch (error) {
-      results.push({ schema_version: 1, status: "error", dry_run: dryRun, source_id: source.source_id, error: error.message });
+      results.push({
+        schema_version: 1,
+        status: "error",
+        dry_run: dryRun,
+        source_id: source.source_id,
+        error_code: error.code ?? (error.message.includes("Source structure changed") ? "source_structure_changed" : "source_processing_failed"),
+        error: error.message,
+        retryable: error.retryable ?? false,
+        attempts: error.attempts ?? 1,
+        source_url: error.sourceUrl,
+        fetches: error.fetches
+      });
     }
   }
   return {

--- a/tests/date-evidence.test.js
+++ b/tests/date-evidence.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+import { createValidators, validateDocument } from "../scripts/validate/schema-validator.js";
+
+const changeSchema = fileURLToPath(new URL("../schemas/change.schema.json", import.meta.url));
+const burdenSchema = fileURLToPath(new URL("../schemas/burden.schema.json", import.meta.url));
+const changePath = new URL("../data/changes/consumption-tax-2019-rate.yaml", import.meta.url);
+const burdenPath = new URL("../data/burdens/consumption-tax.yaml", import.meta.url);
+
+test("all four legal dates remain separate and unknown dates require evidence gaps", async () => {
+  const { change } = await createValidators({ change: changeSchema });
+  const record = parse(await readFile(changePath, "utf8"));
+  assert.deepEqual(validateDocument(change, record, "change"), []);
+
+  const missingField = structuredClone(record);
+  delete missingField.promulgation_date;
+  assert.ok(validateDocument(change, missingField, "missing").some((message) => message.includes("promulgation_date")));
+
+  const inferredUnknown = structuredClone(record);
+  delete inferredUnknown.enforcement_date.evidence_gap_reason;
+  assert.ok(validateDocument(change, inferredUnknown, "unknown").some((message) => message.includes("evidence_gap_reason")));
+});
+
+test("burden main status cannot contain a legislative procedure stage", async () => {
+  const { burden } = await createValidators({ burden: burdenSchema });
+  const record = parse(await readFile(burdenPath, "utf8"));
+  record.current_status = "promulgated";
+  assert.notDeepEqual(validateDocument(burden, record, "burden"), []);
+});

--- a/tests/http-fetcher.test.js
+++ b/tests/http-fetcher.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fetchSourcePages, SourceFetchError } from "../scripts/fetch/http-fetcher.js";
+
+const source = {
+  base_url: "https://example.go.jp/",
+  entry_urls: ["https://example.go.jp/source"],
+  accepted_content_types: ["text/html"]
+};
+
+test("temporary URL failures are retried before succeeding", async () => {
+  let attempts = 0;
+  const pages = await fetchSourcePages(source, {
+    fetchImpl: async () => {
+      attempts += 1;
+      return attempts < 3 ? new Response("temporary", { status: 503 }) : new Response("official", { status: 200, headers: { "content-type": "text/html" } });
+    },
+    sleep: async () => {},
+    now: () => new Date("2026-08-17T01:02:03Z")
+  });
+  assert.equal(attempts, 3);
+  assert.equal(pages[0].body, "official");
+});
+
+test("permanent URL failures stop without retrying", async () => {
+  let attempts = 0;
+  await assert.rejects(fetchSourcePages(source, {
+    fetchImpl: async () => {
+      attempts += 1;
+      return new Response("missing", { status: 404 });
+    },
+    sleep: async () => {}
+  }), (error) => error instanceof SourceFetchError && error.code === "url_permanent_failure");
+  assert.equal(attempts, 1);
+});

--- a/tests/repository-audit.test.js
+++ b/tests/repository-audit.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { auditRepositoryCollections } from "../scripts/audit/repository-audit.js";
+
+function collections() {
+  return {
+    burdens: [{ tax_id: "sample-tax", current_status: "active", current_phases: ["phase-a"], pending_changes: [] }],
+    changes: [{ change_id: "sample-change", tax_ids: ["sample-tax"], events: ["sample-event"], promulgation_date: { date_value: "2020-01-01" }, enforcement_date: { date_value: "2020-02-01" }, application_start_dates: [{ date_value: "2020-03-01" }], collection_start_dates: [{ date_value: null }], source_refs: [] }],
+    events: [{ event_id: "sample-event", change_id: "sample-change" }],
+    phases: [{ phase_id: "phase-a", tax_id: "sample-tax", change_id: "sample-change", subject_scope: "same scope", application_start: "2020-03-01", application_end: null, collection_start: null }],
+    revenues: []
+  };
+}
+
+test("separate legal dates and main burden status pass when consistent", () => {
+  assert.deepEqual(auditRepositoryCollections(collections(), { asOf: "2026-08-17" }), []);
+});
+
+test("date order, phase overlap, reference semantics, and state separation are audited", () => {
+  const input = collections();
+  input.changes[0].promulgation_date.date_value = "2020-04-01";
+  input.phases.push({ ...input.phases[0], phase_id: "phase-b", application_start: "2020-04-01" });
+  input.burdens[0].current_status = "ended";
+  input.events[0].change_id = "another-change";
+  const findings = auditRepositoryCollections(input, { asOf: "2026-08-17" });
+  assert.ok(findings.some(({ code }) => code === "date_order_requires_review"));
+  assert.ok(findings.some(({ code }) => code === "phase_period_overlap"));
+  assert.ok(findings.some(({ code }) => code === "event_change_mismatch"));
+  assert.ok(findings.some(({ code }) => code === "burden_status_mismatch"));
+});
+
+test("amount scope detects missing inner-total evidence and possible double counting", () => {
+  const input = collections();
+  const base = { tax_id: "sample-tax", period_start: "2025-04-01", period_end: "2026-03-31", amount_yen: "100", accounting_basis: "settlement", consolidation_scope: "national" };
+  input.revenues = [
+    { ...base, record_id: "inner", value_status: "included_in_parent_total", evidence_gap_reason: "" },
+    { ...base, record_id: "first", value_status: "available", evidence_gap_reason: "" },
+    { ...base, record_id: "second", value_status: "available", evidence_gap_reason: "" }
+  ];
+  const findings = auditRepositoryCollections(input, { asOf: "2026-08-17" });
+  assert.ok(findings.some(({ code }) => code === "amount_scope_reason_missing"));
+  assert.ok(findings.some(({ code }) => code === "possible_amount_double_count"));
+});

--- a/tests/repository-validator.test.js
+++ b/tests/repository-validator.test.js
@@ -30,16 +30,24 @@ test("source scan workflow is fixed, scheduled, and manually runnable", async ()
   assert.equal(workflow.jobs["update-pr"].permissions.contents, "write");
   assert.equal(workflow.jobs["update-pr"].permissions["pull-requests"], "write");
   assert.equal(workflow.jobs["update-pr"].needs, "scan");
+  assert.equal(workflow.jobs["audit-issues"].permissions.contents, "read");
+  assert.equal(workflow.jobs["audit-issues"].permissions.issues, "write");
+  assert.equal(workflow.jobs["audit-issues"].needs, "scan");
+  assert.match(workflow.jobs["audit-issues"].if, /always\(\)/);
   assert.equal(workflow.concurrency.group, "official-source-update");
   assert.equal(workflow.concurrency["cancel-in-progress"], false);
   const scanCommands = workflow.jobs.scan.steps.map(({ run }) => run).filter(Boolean);
   const updateCommands = workflow.jobs["update-pr"].steps.map(({ run }) => run).filter(Boolean);
   assert.ok(scanCommands.includes("npm test"));
   assert.ok(scanCommands.includes("npm run validate"));
+  assert.ok(scanCommands.some((command) => command.includes("npm run audit")));
   assert.ok(scanCommands.some((command) => command.includes("--all")));
+  assert.ok(scanCommands.some((command) => command.includes("npm run audit:scan")));
   assert.ok(updateCommands.some((command) => command.includes("npm run prepare-update")));
   assert.ok(updateCommands.some((command) => command.includes("gh pr list") && command.includes("gh pr edit") && command.includes("gh pr create")));
   assert.ok([...scanCommands, ...updateCommands].every((command) => !command.includes("gh pr merge")));
+  const issueCommands = workflow.jobs["audit-issues"].steps.map(({ run }) => run).filter(Boolean);
+  assert.ok(issueCommands.some((command) => command.includes("npm run audit:issues")));
 });
 
 test("revenue schema distinguishes an unavailable amount from zero", async () => {

--- a/tests/source-pipeline.test.js
+++ b/tests/source-pipeline.test.js
@@ -67,6 +67,14 @@ test("one source failure does not starve later sources and makes the aggregate f
   assert.match(result.results[0].error, /Fetch failed \(503\)/);
 });
 
+test("structure failures retain fetched hashes for the audit trail", async () => {
+  const source = await loadEnabledSource(root, "nta-consumption-tax-rates");
+  const result = await runConfiguredSources({ root, sources: [source], fetchImpl: fixtureFetch((body) => body.replace("週2回以上発行", "")), now, dryRun: true });
+  assert.equal(result.results[0].error_code, "source_structure_changed");
+  assert.equal(result.results[0].fetches.length, 2);
+  assert.ok(result.results[0].fetches.every(({ source_url, sha256 }) => source_url && /^[a-f0-9]{64}$/.test(sha256)));
+});
+
 test("fetch and structure failures reject the whole run", async () => {
   await assert.rejects(
     runSourcePipeline({ root, sourceId: "nta-consumption-tax-rates", fetchImpl: async () => new Response("failure", { status: 503 }), now }),

--- a/tests/source-scan-audit.test.js
+++ b/tests/source-scan-audit.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { auditSourceScan, issueCandidatesFromAudit } from "../scripts/audit/source-scan-audit.js";
+import { publishAuditIssues } from "../scripts/audit/publish-audit-issues.js";
+
+const fetchedAt = "2026-08-17T01:02:03.000Z";
+const fetches = [{ source_url: "https://example.go.jp/source", fetched_at: fetchedAt, sha256: "a".repeat(64) }];
+
+test("source failures become reproducible issue candidates without changing data", () => {
+  const scan = {
+    schema_version: 1,
+    status: "error",
+    completed_at: fetchedAt,
+    results: [{ source_id: "official-source", status: "error", error_code: "url_transient_failure", error: "503 after retries", source_url: "https://example.go.jp/source" }]
+  };
+  const report = auditSourceScan(scan);
+  const candidates = issueCandidatesFromAudit(report);
+  assert.equal(report.status, "needs_review");
+  assert.equal(report.summary.transient_failures, 1);
+  assert.equal(candidates.length, 1);
+  assert.match(candidates[0].body, /正本データは変更していません/);
+  assert.match(candidates[0].body, /audit-topic:audit-[a-f0-9]{20}/);
+  const changedMessage = auditSourceScan({ ...scan, results: [{ ...scan.results[0], error: "502 after retries" }] });
+  assert.equal(changedMessage.findings[0].topic_key, report.findings[0].topic_key);
+});
+
+test("unmapped changes and official-source disagreements require review", () => {
+  const target = { file: "data/phases/sample.yaml", record_id_field: "phase_id", record_id: "sample-phase", path: "value.numeric_value" };
+  const scan = {
+    schema_version: 1,
+    status: "change_detected",
+    completed_at: fetchedAt,
+    results: [
+      { source_id: "source-a", status: "change_detected", fetches, candidate_diff: [{ fact_id: "unmapped", target: null, current: 1, candidate: 2 }, { fact_id: "rate", target, current: 1, candidate: 2 }] },
+      { source_id: "source-b", status: "change_detected", fetches, candidate_diff: [{ fact_id: "rate", target, current: 1, candidate: 3 }] }
+    ]
+  };
+  const report = auditSourceScan(scan);
+  assert.ok(report.findings.some(({ code }) => code === "unmapped_official_change"));
+  assert.ok(report.findings.some(({ code }) => code === "official_source_disagreement"));
+  assert.equal(report.summary.source_disagreements, 1);
+  assert.equal(report.reproducibility.length, 2);
+});
+
+test("publishing reuses an open topic and creates only missing issues", async () => {
+  const candidates = [
+    { topic_key: "audit-existing", marker: "[audit-topic:audit-existing]", title: "existing", body: "existing" },
+    { topic_key: "audit-new", marker: "[audit-topic:audit-new]", title: "new", body: "new" }
+  ];
+  const created = [];
+  const commented = [];
+  const results = await publishAuditIssues({
+    candidates,
+    findOpen: async (marker) => marker.includes("existing") ? { number: 12, html_url: "https://example.test/12" } : null,
+    comment: async (number, candidate) => commented.push([number, candidate.topic_key]),
+    create: async (candidate) => {
+      created.push(candidate.topic_key);
+      return { number: 13, html_url: "https://example.test/13" };
+    }
+  });
+  assert.deepEqual(created, ["audit-new"]);
+  assert.deepEqual(commented, [[12, "audit-existing"]]);
+  assert.deepEqual(results.map(({ status }) => status), ["updated", "created"]);
+});


### PR DESCRIPTION
## 概要

Closes #8

公式情報の自動更新で誤った制度情報を登録しないため、正本の意味的監査、URL一時障害の再試行、取得・構造・ソース不一致の監査レポート、不確実事項の重複防止付きIssue化を実装しました。

確定的な差分は既存の#9のPR経路へ進み、不確実な差分は正本を変更せずIssueへ分岐します。Workflowファイルは増やさず、既存の `source-scan.yml` を拡張しています。

## 受け入れ条件

- [x] 公布日、施行日、適用開始日、徴収開始日を必須の別項目として検証
- [x] 不明日付では `null`、原文、精度、根拠不足理由を要求し、推測補完を禁止
- [x] phase期間の逆転・重複・空白と、change・tax参照の意味的不整合を検出
- [x] 主状態と法律手続状態を別Schemaとして検証し、phaseから主状態を再導出
- [x] 取得失敗、構造変更、対象不明、公式ソース間不一致を監査レポートへ記録
- [x] 一時的なHTTP障害は最大3回再試行し、恒久障害は即時報告
- [x] 不確実な変更はデータ変更PRへ含めずIssue候補へ変換
- [x] 安定した `[audit-topic:...]` で未解決Issueを検索し、重複作成を防止
- [x] 同一Issueの再検知時は確認結果をコメントとして追記
- [x] 取得URL、取得日時、原文SHA-256を監査レポートへ保存
- [x] 金額の期間・単位・集計範囲・内数・二重計上候補を監査
- [x] 正常系・異常系テストを追加

## 作業・検証の分担

- 主担当: Codex
- 調査・検証担当: 主担当がIssue範囲、Schema、Workflow権限、監査履歴を一貫して確認
- 独立検証の結果: 通常Issueとして追加エージェントを使用せず、単体・Schema・実巡回で検証

## 根拠

- 公式URL: https://laws.e-gov.go.jp/api/2/law_data/363AC0000000108
- 公式URL: https://laws.e-gov.go.jp/api/2/law_data/325AC0000000226
- 公式URL: https://www.nta.go.jp/taxes/shiraberu/taxanswer/shohi/6101.htm
- 公式URL: https://www.nta.go.jp/taxes/shiraberu/taxanswer/shohi/6102.htm
- 確認日時: 2026-08-17T13:33:07Z

## データへの影響

- 対象ID: なし
- 旧値: 変更なし
- 新値: 変更なし
- 現在の正本監査: エラー0件、警告0件
- 公式ソース実巡回: `no_change`

## GitHub Actionsの権限

- 巡回job: `contents: read`
- データ更新PR job: `contents: write`, `pull-requests: write`
- 不確実事項Issue job: `contents: read`, `issues: write`
- 自動マージ、mainへの直接push、Issue削除は行わない

## 検証

- `npm ci`: 成功、脆弱性0件
- `npm test`: 39件成功
- `npm run validate`: 成功
- `npm run audit -- --as-of 2026-08-17`: `clean`、エラー0件、警告0件
- `npm run scan -- --all --dry-run`: `no_change`
- `npm run audit:scan`: `clean`、監査所見0件
- `git diff --check`: 成功

## 未解決・不確実な点

- URL到達性の再試行と構造検証は `automation_enabled` の公式ソースを対象とします。手動確認用sourceはadapter実装後に同じ監査経路へ加わります。
- 成立・解決したIssueは自動削除しません。人間が公式根拠と関連PRを追記し、Closeする運用です。

## 確認事項

- [x] 対応するIssueの範囲内の変更である
- [x] PRの送信先は `main` である
- [x] 推測値を確定値として記録していない
- [x] `npm test` と `npm run validate` を実行した
- [x] エージェントはマージせず、人間のレビューとマージ判断を待つ
