### PR TITLE
全監視対象のadapter実装計画を棚卸しする

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,5 +18,6 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run validate
+      - run: npm run inventory:check
       - run: npm run semantics:check
       - run: npm run generate:check

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ reports/      生成レポート
 
 - `config/sources.yaml` は巡回先と利用条件を管理する情報源レジストリです。
 - `config/monitoring.yaml` は正本制度ごとの監視可否、複数source、対象ID、抽出対象を管理します。詳細は[初期マスタ監視設定](docs/monitoring-configuration.md)を参照してください。
+- `config/adapter-inventory.yaml` は全監視targetの実装Issue、優先度、batch、公式情報形式、必要adapter、抽出可否を管理する再生成可能な棚卸しです。
 - `data/burdens`、`data/changes`、`data/events`、`data/phases`、`data/revenue`、`data/reconciliation` はレビュー後にGitで履歴管理する正本です。
 - 初期マスタの投入件数と未解決事項は[初期マスタ投入・検証レポート](docs/initial-master-import-report.md)を参照してください。
 - `data/candidates` は初期マスタへ昇格する前の調査候補です。Schema検証とGitレビューの対象ですが、確定制度マスタや配布対象として扱いません。適合性と昇格条件は[初期マスタ候補のSchema適合性確認](docs/initial-master-schema-fit.md)、税以外の候補の収集範囲は[税以外の公的負担候補の収集・照合](docs/public-burden-candidate-reconciliation.md)、統合判定は[初期マスタ投入対象の統合判定](docs/initial-master-selection.md)を参照してください。
@@ -52,6 +53,7 @@ Node.js 20以降で実行できます。最初に検証用パッケージをイ�
 npm ci
 npm test
 npm run validate
+npm run inventory:check
 npm run semantics:check
 ```
 

--- a/config/adapter-inventory.yaml
+++ b/config/adapter-inventory.yaml
@@ -1,0 +1,3638 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-19T20:13:25+09:00",
+  "batch_policy": {
+    "default_max_targets": 15,
+    "hard_max_targets": 20,
+    "common_source_exception": "one_common_source_unit"
+  },
+  "targets": [
+    {
+      "tax_id": "adverse-drug-reaction-contribution",
+      "official_name": "副作用拠出金",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-03",
+      "reuse_group": "egov_law_api_json:414AC0000000192",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "414AC0000000192",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:414AC0000000192"
+        }
+      ]
+    },
+    {
+      "tax_id": "agricultural-cooperative-savings-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-02",
+      "reuse_group": "egov_law_api_json:348AC0000000053",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "348AC0000000053",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:348AC0000000053"
+        }
+      ]
+    },
+    {
+      "tax_id": "agricultural-cooperative-savings-insurance-premium",
+      "official_name": "unknown",
+      "burden_type": "insurance_premium",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-02",
+      "reuse_group": "egov_law_api_json:348AC0000000053",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "348AC0000000053",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:348AC0000000053"
+        }
+      ]
+    },
+    {
+      "tax_id": "agricultural-cooperative-savings-special-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-02",
+      "reuse_group": "egov_law_api_json:348AC0000000053",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "348AC0000000053",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:348AC0000000053"
+        }
+      ]
+    },
+    {
+      "tax_id": "asbestos-relief-general-contribution",
+      "official_name": "石綿健康被害救済一般拠出金",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-04",
+      "reuse_group": "egov_law_api_json:418AC0000000004",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "418AC0000000004",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:418AC0000000004"
+        }
+      ]
+    },
+    {
+      "tax_id": "asbestos-relief-special-contribution",
+      "official_name": "石綿健康被害救済特別拠出金",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-04",
+      "reuse_group": "egov_law_api_json:418AC0000000004",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "418AC0000000004",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:418AC0000000004"
+        }
+      ]
+    },
+    {
+      "tax_id": "automobile-accident-countermeasure-levy",
+      "official_name": "自動車事故対策事業賦課金",
+      "burden_type": "levy",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-01",
+      "reuse_group": "egov_law_api_json:330AC0000000097",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "330AC0000000097",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:330AC0000000097"
+        }
+      ]
+    },
+    {
+      "tax_id": "automobile-tax",
+      "official_name": "自動車税",
+      "burden_type": "local_tax",
+      "implementation_issue": 39,
+      "implementation_status": "implemented_initial",
+      "priority": "completed",
+      "depends_on_issues": [],
+      "batch_id": "issue-39-batch-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "implemented",
+        "taxable_scope": "planned",
+        "calculation_basis": "planned",
+        "rate_or_amount": "implemented",
+        "applicable_period": "planned"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "implemented",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "automobile-weight-tax",
+      "official_name": "自動車重量税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:346AC0000000089",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "346AC0000000089",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:346AC0000000089"
+        }
+      ]
+    },
+    {
+      "tax_id": "aviation-fuel-tax",
+      "official_name": "航空機燃料税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:347AC0000000007",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "347AC0000000007",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:347AC0000000007"
+        }
+      ]
+    },
+    {
+      "tax_id": "banks-shareholdings-purchase-corporation-contribution",
+      "official_name": "銀行等保有株式取得機構に対する拠出金",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-03",
+      "reuse_group": "egov_law_api_json:413AC0000000131",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "413AC0000000131",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:413AC0000000131"
+        }
+      ]
+    },
+    {
+      "tax_id": "bathing-tax",
+      "official_name": "入湯税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "broadband-service-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-02",
+      "reuse_group": "egov_law_api_json:359AC0000000086",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "359AC0000000086",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:359AC0000000086"
+        }
+      ]
+    },
+    {
+      "tax_id": "business-office-tax",
+      "official_name": "事業所税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "child-care-contribution",
+      "official_name": "子ども・子育て拠出金",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-04",
+      "reuse_group": "egov_law_api_json:424AC0000000065",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "424AC0000000065",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:424AC0000000065"
+        }
+      ]
+    },
+    {
+      "tax_id": "city-planning-tax",
+      "official_name": "都市計画税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "commodity-customer-protection-fund-charge",
+      "official_name": "日本商品委託者保護基金に対する負担金",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-01",
+      "reuse_group": "egov_law_api_json:325AC0000000239",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000239",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000239"
+        }
+      ]
+    },
+    {
+      "tax_id": "common-facilities-tax",
+      "official_name": "共同施設税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "common-utility-tunnel-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-01",
+      "reuse_group": "egov_law_api_json:338AC0000000081",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "338AC0000000081",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:338AC0000000081"
+        }
+      ]
+    },
+    {
+      "tax_id": "consumption-tax",
+      "official_name": "消費税",
+      "burden_type": "national_tax",
+      "implementation_issue": 39,
+      "implementation_status": "implemented_initial",
+      "priority": "completed",
+      "depends_on_issues": [],
+      "batch_id": "issue-39-batch-01",
+      "reuse_group": "egov_law_api_json:363AC0000000108+html:www.nta.go.jp+html:www.nta.go.jp",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "implemented",
+        "taxable_scope": "implemented",
+        "calculation_basis": "implemented",
+        "rate_or_amount": "implemented",
+        "applicable_period": "planned"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "363AC0000000108",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "egov_law_article_facts",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "implemented",
+          "reuse_key": "egov_law_api_json:363AC0000000108"
+        },
+        {
+          "source_id": "nta-consumption-tax-rates",
+          "target_id": "6101.htm",
+          "official_format": "html",
+          "current_adapter": "html_regex_facts",
+          "required_adapter": "html_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "html:www.nta.go.jp",
+          "shared_format_issue": 46
+        },
+        {
+          "source_id": "nta-consumption-tax-rates",
+          "target_id": "nta-consumption-tax-rates-page-2",
+          "official_format": "html",
+          "current_adapter": "html_regex_facts",
+          "required_adapter": "html_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "html:www.nta.go.jp",
+          "shared_format_issue": 46
+        }
+      ]
+    },
+    {
+      "tax_id": "corporation-tax",
+      "official_name": "法人税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:340AC0000000034",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "340AC0000000034",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:340AC0000000034"
+        }
+      ]
+    },
+    {
+      "tax_id": "customs-duty",
+      "official_name": "関税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:329AC0000000061",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "329AC0000000061",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:329AC0000000061"
+        }
+      ]
+    },
+    {
+      "tax_id": "deposit-insurance-corporation-charge",
+      "official_name": "預金保険機構に対する負担金",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-02",
+      "reuse_group": "egov_law_api_json:346AC0000000034",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "346AC0000000034",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:346AC0000000034"
+        }
+      ]
+    },
+    {
+      "tax_id": "deposit-insurance-corporation-special-charge",
+      "official_name": "預金保険機構に対する特定負担金",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-02",
+      "reuse_group": "egov_law_api_json:346AC0000000034",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "346AC0000000034",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:346AC0000000034"
+        }
+      ]
+    },
+    {
+      "tax_id": "deposit-insurance-premium",
+      "official_name": "預金保険料",
+      "burden_type": "insurance_premium",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-02",
+      "reuse_group": "egov_law_api_json:346AC0000000034",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "346AC0000000034",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:346AC0000000034"
+        }
+      ]
+    },
+    {
+      "tax_id": "disability-employment-levy",
+      "official_name": "障害者雇用納付金",
+      "burden_type": "payment",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-01",
+      "reuse_group": "egov_law_api_json:335AC0000000123",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "335AC0000000123",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:335AC0000000123"
+        }
+      ]
+    },
+    {
+      "tax_id": "east-japan-business-rehabilitation-contribution",
+      "official_name": "unknown",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-04",
+      "reuse_group": "egov_law_api_json:423AC0100000113",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "423AC0100000113",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:423AC0100000113"
+        }
+      ]
+    },
+    {
+      "tax_id": "educational-public-transmission-compensation",
+      "official_name": "授業目的公衆送信補償金",
+      "burden_type": "payment",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-01",
+      "reuse_group": "egov_law_api_json:345AC0000000048",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "345AC0000000048",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:345AC0000000048"
+        }
+      ]
+    },
+    {
+      "tax_id": "electricity-business-compensation-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-03",
+      "reuse_group": "egov_law_api_json:407M50000400077",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "407M50000400077",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:407M50000400077"
+        }
+      ]
+    },
+    {
+      "tax_id": "employment-insurance-premium",
+      "official_name": "雇用保険料",
+      "burden_type": "social_insurance_premium",
+      "implementation_issue": 44,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-44-batch-01",
+      "reuse_group": "egov_law_api_json:349AC0000000116",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "349AC0000000116",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:349AC0000000116"
+        }
+      ]
+    },
+    {
+      "tax_id": "enterprise-tax",
+      "official_name": "事業税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "fixed-asset-tax",
+      "official_name": "固定資産税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "forest-environment-tax",
+      "official_name": "森林環境税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-02",
+      "reuse_group": "egov_law_api_json:431AC0000000003",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "431AC0000000003",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:431AC0000000003"
+        }
+      ]
+    },
+    {
+      "tax_id": "fossil-fuel-levy",
+      "official_name": "化石燃料賦課金",
+      "burden_type": "levy",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-05",
+      "reuse_group": "egov_law_api_json:505AC0000000032",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "505AC0000000032",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:505AC0000000032"
+        }
+      ]
+    },
+    {
+      "tax_id": "gasoline-tax",
+      "official_name": "揮発油税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:332AC0000000055",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "332AC0000000055",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:332AC0000000055"
+        }
+      ]
+    },
+    {
+      "tax_id": "golf-course-utilization-tax",
+      "official_name": "ゴルフ場利用税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "gx-specified-business-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-05",
+      "reuse_group": "egov_law_api_json:505AC0000000032",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "505AC0000000032",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:505AC0000000032"
+        }
+      ]
+    },
+    {
+      "tax_id": "hepatitis-c-special-relief-contribution",
+      "official_name": "unknown",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-04",
+      "reuse_group": "egov_law_api_json:420AC1000000002",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "420AC1000000002",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:420AC1000000002"
+        }
+      ]
+    },
+    {
+      "tax_id": "high-level-waste-disposal-contribution",
+      "official_name": "unknown",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-03",
+      "reuse_group": "egov_law_api_json:412AC0000000117",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "412AC0000000117",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:412AC0000000117"
+        }
+      ]
+    },
+    {
+      "tax_id": "hunting-tax",
+      "official_name": "狩猟税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "imported-sugar-adjustment-charge",
+      "official_name": "unknown",
+      "burden_type": "adjustment_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-01",
+      "reuse_group": "egov_law_api_json:340AC0000000109",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "340AC0000000109",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:340AC0000000109"
+        }
+      ]
+    },
+    {
+      "tax_id": "income-tax",
+      "official_name": "所得税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:340AC0000000033",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "340AC0000000033",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:340AC0000000033"
+        }
+      ]
+    },
+    {
+      "tax_id": "infection-contribution",
+      "official_name": "感染拠出金",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-03",
+      "reuse_group": "egov_law_api_json:414AC0000000192",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "414AC0000000192",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:414AC0000000192"
+        }
+      ]
+    },
+    {
+      "tax_id": "inheritance-and-gift-tax",
+      "official_name": "unknown",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:325AC0000000073",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000073",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000073"
+        }
+      ]
+    },
+    {
+      "tax_id": "international-oil-pollution-fund-annual-contribution",
+      "official_name": "unknown",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-02",
+      "reuse_group": "egov_law_api_json:350AC0000000095",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "350AC0000000095",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:350AC0000000095"
+        }
+      ]
+    },
+    {
+      "tax_id": "international-tourist-tax",
+      "official_name": "国際観光旅客税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-02",
+      "reuse_group": "egov_law_api_json:430AC0000000016",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "430AC0000000016",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:430AC0000000016"
+        }
+      ]
+    },
+    {
+      "tax_id": "investor-protection-fund-charge",
+      "official_name": "日本投資者保護基金に対する負担金",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-01",
+      "reuse_group": "egov_law_api_json:323AC0000000025",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "323AC0000000025",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:323AC0000000025"
+        }
+      ]
+    },
+    {
+      "tax_id": "irrigation-water-facility-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-03",
+      "reuse_group": "egov_law_api_json:414AC0000000182",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "414AC0000000182",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:414AC0000000182"
+        }
+      ]
+    },
+    {
+      "tax_id": "library-public-transmission-compensation",
+      "official_name": "図書館等公衆送信補償金",
+      "burden_type": "payment",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-01",
+      "reuse_group": "egov_law_api_json:345AC0000000048",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "345AC0000000048",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:345AC0000000048"
+        }
+      ]
+    },
+    {
+      "tax_id": "light-motor-vehicle-tax",
+      "official_name": "軽自動車税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "light-oil-delivery-tax",
+      "official_name": "軽油引取税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "liquor-tax",
+      "official_name": "酒税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:328AC0000000006",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "328AC0000000006",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:328AC0000000006"
+        }
+      ]
+    },
+    {
+      "tax_id": "local-consumption-tax",
+      "official_name": "地方消費税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "local-corporation-tax",
+      "official_name": "地方法人税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-02",
+      "reuse_group": "egov_law_api_json:426AC0000000011",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "426AC0000000011",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:426AC0000000011"
+        }
+      ]
+    },
+    {
+      "tax_id": "local-gasoline-tax",
+      "official_name": "地方揮発油税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:330AC0000000104",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "330AC0000000104",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:330AC0000000104"
+        }
+      ]
+    },
+    {
+      "tax_id": "local-tobacco-tax",
+      "official_name": "地方たばこ税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "long-term-care-insurance-premium",
+      "official_name": "unknown",
+      "burden_type": "social_insurance_premium",
+      "implementation_issue": 44,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-44-batch-01",
+      "reuse_group": "egov_law_api_json:409AC0000000123",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "409AC0000000123",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:409AC0000000123"
+        }
+      ]
+    },
+    {
+      "tax_id": "medical-insurance-premium",
+      "official_name": "unknown",
+      "burden_type": "social_insurance_premium",
+      "implementation_issue": 44,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-44-batch-01",
+      "reuse_group": "egov_law_api_json:211AC0000000070+egov_law_api_json:333AC0000000192+egov_law_api_json:357AC0000000080",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "211AC0000000070",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:211AC0000000070"
+        },
+        {
+          "source_id": "egov-laws",
+          "target_id": "333AC0000000192",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:333AC0000000192"
+        },
+        {
+          "source_id": "egov-laws",
+          "target_id": "357AC0000000080",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:357AC0000000080"
+        }
+      ]
+    },
+    {
+      "tax_id": "minamata-specified-business-compensation-levy",
+      "official_name": "unknown",
+      "burden_type": "levy",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-04",
+      "reuse_group": "egov_law_api_json:421AC1000000081",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "421AC1000000081",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:421AC1000000081"
+        }
+      ]
+    },
+    {
+      "tax_id": "mineral-product-tax",
+      "official_name": "鉱産税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "mining-area-tax",
+      "official_name": "鉱区税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "mining-pollution-prevention-fund-contribution",
+      "official_name": "鉱害防止事業基金に対する拠出金",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-02",
+      "reuse_group": "egov_law_api_json:348AC0000000026",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "348AC0000000026",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:348AC0000000026"
+        }
+      ]
+    },
+    {
+      "tax_id": "multipurpose-dam-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-01",
+      "reuse_group": "egov_law_api_json:332AC0000000035",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "332AC0000000035",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:332AC0000000035"
+        }
+      ]
+    },
+    {
+      "tax_id": "national-health-insurance-tax",
+      "official_name": "国民健康保険税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "non-statutory-ordinary-tax-category",
+      "official_name": "法定外普通税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "non-statutory-purpose-tax-category",
+      "official_name": "法定外目的税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "nuclear-damage-support-general-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-04",
+      "reuse_group": "egov_law_api_json:423AC0000000094",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "423AC0000000094",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:423AC0000000094"
+        }
+      ]
+    },
+    {
+      "tax_id": "nuclear-damage-support-special-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-04",
+      "reuse_group": "egov_law_api_json:423AC0000000094",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "423AC0000000094",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:423AC0000000094"
+        }
+      ]
+    },
+    {
+      "tax_id": "nuclear-decommissioning-contribution",
+      "official_name": "unknown",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-04",
+      "reuse_group": "egov_law_api_json:417AC0000000048",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "417AC0000000048",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:417AC0000000048"
+        }
+      ]
+    },
+    {
+      "tax_id": "participant-protection-trust-charge",
+      "official_name": "加入者保護信託への負担金",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-03",
+      "reuse_group": "egov_law_api_json:413AC0000000075",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "413AC0000000075",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:413AC0000000075"
+        }
+      ]
+    },
+    {
+      "tax_id": "pension-insurance-premium",
+      "official_name": "unknown",
+      "burden_type": "social_insurance_premium",
+      "implementation_issue": 44,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-44-batch-01",
+      "reuse_group": "egov_law_api_json:329AC0000000115+egov_law_api_json:334AC0000000141",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "329AC0000000115",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:329AC0000000115"
+        },
+        {
+          "source_id": "egov-laws",
+          "target_id": "334AC0000000141",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:334AC0000000141"
+        }
+      ]
+    },
+    {
+      "tax_id": "petroleum-and-coal-tax",
+      "official_name": "石油石炭税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-02",
+      "reuse_group": "egov_law_api_json:353AC0000000025",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "353AC0000000025",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:353AC0000000025"
+        }
+      ]
+    },
+    {
+      "tax_id": "petroleum-gas-tax",
+      "official_name": "石油ガス税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:340AC0000000156",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "340AC0000000156",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:340AC0000000156"
+        }
+      ]
+    },
+    {
+      "tax_id": "pharmaceutical-safety-contribution",
+      "official_name": "unknown",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-03",
+      "reuse_group": "egov_law_api_json:414AC0000000192",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "414AC0000000192",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:414AC0000000192"
+        }
+      ]
+    },
+    {
+      "tax_id": "policyholder-protection-fund-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-03",
+      "reuse_group": "egov_law_api_json:407AC0000000105",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "407AC0000000105",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:407AC0000000105"
+        }
+      ]
+    },
+    {
+      "tax_id": "pollution-load-levy",
+      "official_name": "汚染負荷量賦課金",
+      "burden_type": "levy",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-02",
+      "reuse_group": "egov_law_api_json:348AC0000000111",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "348AC0000000111",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:348AC0000000111"
+        }
+      ]
+    },
+    {
+      "tax_id": "pollution-prevention-project-business-charge",
+      "official_name": "公害防止事業費事業者負担金",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-01",
+      "reuse_group": "egov_law_api_json:345AC0000000133",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "345AC0000000133",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:345AC0000000133"
+        }
+      ]
+    },
+    {
+      "tax_id": "port-environment-improvement-charge",
+      "official_name": "港湾環境整備負担金",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-01",
+      "reuse_group": "egov_law_api_json:325AC0000000218",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000218",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000218"
+        }
+      ]
+    },
+    {
+      "tax_id": "postal-network-support-contribution",
+      "official_name": "unknown",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-04",
+      "reuse_group": "egov_law_api_json:417AC0000000101",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "417AC0000000101",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:417AC0000000101"
+        }
+      ]
+    },
+    {
+      "tax_id": "postal-transport-consignment-compensation",
+      "official_name": "郵便物運送委託補償金",
+      "burden_type": "payment",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-01",
+      "reuse_group": "egov_law_api_json:324AC0000000284",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "324AC0000000284",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:324AC0000000284"
+        }
+      ]
+    },
+    {
+      "tax_id": "power-development-promotion-tax",
+      "official_name": "電源開発促進税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:349AC0000000079",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "349AC0000000079",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:349AC0000000079"
+        }
+      ]
+    },
+    {
+      "tax_id": "private-recording-compensation",
+      "official_name": "私的録音録画補償金",
+      "burden_type": "payment",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-01",
+      "reuse_group": "egov_law_api_json:345AC0000000048",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "345AC0000000048",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:345AC0000000048"
+        }
+      ]
+    },
+    {
+      "tax_id": "railway-barrier-free-fee",
+      "official_name": "unknown",
+      "burden_type": "fee",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-02",
+      "reuse_group": "egov_law_api_json:361AC0000000092",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "361AC0000000092",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:361AC0000000092"
+        }
+      ]
+    },
+    {
+      "tax_id": "real-estate-acquisition-tax",
+      "official_name": "不動産取得税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "reconstruction-special-income-tax",
+      "official_name": "復興特別所得税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-02",
+      "reuse_group": "egov_law_api_json:423AC0000000117",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "423AC0000000117",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:423AC0000000117"
+        }
+      ]
+    },
+    {
+      "tax_id": "regional-economy-revitalization-contribution",
+      "official_name": "unknown",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-04",
+      "reuse_group": "egov_law_api_json:421AC0000000063",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "421AC0000000063",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:421AC0000000063"
+        }
+      ]
+    },
+    {
+      "tax_id": "registration-and-license-tax",
+      "official_name": "登録免許税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:342AC0000000035",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "342AC0000000035",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:342AC0000000035"
+        }
+      ]
+    },
+    {
+      "tax_id": "renewable-energy-surcharge",
+      "official_name": "再生可能エネルギー発電促進賦課金",
+      "burden_type": "levy",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-04",
+      "reuse_group": "egov_law_api_json:423AC0000000108",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "423AC0000000108",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:423AC0000000108"
+        }
+      ]
+    },
+    {
+      "tax_id": "reprocessing-contribution",
+      "official_name": "再処理等拠出金",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-04",
+      "reuse_group": "egov_law_api_json:417AC0000000048",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "417AC0000000048",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:417AC0000000048"
+        }
+      ]
+    },
+    {
+      "tax_id": "resident-tax",
+      "official_name": "住民税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "residential-land-development-tax",
+      "official_name": "宅地開発税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "special-corporate-enterprise-tax",
+      "official_name": "特別法人事業税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-02",
+      "reuse_group": "egov_law_api_json:431AC0000000004",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "431AC0000000004",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:431AC0000000004"
+        }
+      ]
+    },
+    {
+      "tax_id": "special-landholding-tax",
+      "official_name": "特別土地保有税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "special-tobacco-tax",
+      "official_name": "たばこ特別税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-02",
+      "reuse_group": "egov_law_api_json:410AC0000000137",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "410AC0000000137",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:410AC0000000137"
+        }
+      ]
+    },
+    {
+      "tax_id": "special-tonnage-tax",
+      "official_name": "特別とん税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:332AC0000000038",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "332AC0000000038",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:332AC0000000038"
+        }
+      ]
+    },
+    {
+      "tax_id": "specified-pollution-levy",
+      "official_name": "unknown",
+      "burden_type": "levy",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-02",
+      "reuse_group": "egov_law_api_json:348AC0000000111",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "348AC0000000111",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:348AC0000000111"
+        }
+      ]
+    },
+    {
+      "tax_id": "stamp-tax",
+      "official_name": "印紙税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:342AC0000000023",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "342AC0000000023",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:342AC0000000023"
+        }
+      ]
+    },
+    {
+      "tax_id": "supplementary-nuclear-damage-general-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-05",
+      "reuse_group": "egov_law_api_json:426AC0000000133",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "426AC0000000133",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:426AC0000000133"
+        }
+      ]
+    },
+    {
+      "tax_id": "supplementary-nuclear-damage-special-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-05",
+      "reuse_group": "egov_law_api_json:426AC0000000133",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "426AC0000000133",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:426AC0000000133"
+        }
+      ]
+    },
+    {
+      "tax_id": "supplementary-oil-pollution-fund-annual-contribution",
+      "official_name": "unknown",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-02",
+      "reuse_group": "egov_law_api_json:350AC0000000095",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "350AC0000000095",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:350AC0000000095"
+        }
+      ]
+    },
+    {
+      "tax_id": "taxi-center-business-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-04",
+      "reuse_group": "egov_law_api_json:421AC0000000064",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "421AC0000000064",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:421AC0000000064"
+        }
+      ]
+    },
+    {
+      "tax_id": "telephone-accessibility-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-05",
+      "reuse_group": "egov_law_api_json:502AC0000000053",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "502AC0000000053",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:502AC0000000053"
+        }
+      ]
+    },
+    {
+      "tax_id": "tobacco-tax",
+      "official_name": "たばこ税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-02",
+      "reuse_group": "egov_law_api_json:359AC0000000072",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "359AC0000000072",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:359AC0000000072"
+        }
+      ]
+    },
+    {
+      "tax_id": "tonnage-tax",
+      "official_name": "とん税",
+      "burden_type": "national_tax",
+      "implementation_issue": 42,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-42-batch-01",
+      "reuse_group": "egov_law_api_json:332AC0000000037",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "332AC0000000037",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:332AC0000000037"
+        }
+      ]
+    },
+    {
+      "tax_id": "tru-waste-disposal-contribution",
+      "official_name": "unknown",
+      "burden_type": "contribution",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-03",
+      "reuse_group": "egov_law_api_json:412AC0000000117",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "412AC0000000117",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:412AC0000000117"
+        }
+      ]
+    },
+    {
+      "tax_id": "universal-service-fee",
+      "official_name": "unknown",
+      "burden_type": "fee",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-02",
+      "reuse_group": "egov_law_api_json:359AC0000000086",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "359AC0000000086",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:359AC0000000086"
+        }
+      ]
+    },
+    {
+      "tax_id": "utility-tunnel-management-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-03",
+      "reuse_group": "egov_law_api_json:407AC0000000039",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "407AC0000000039",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:407AC0000000039"
+        }
+      ]
+    },
+    {
+      "tax_id": "utility-tunnel-other-occupant-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-03",
+      "reuse_group": "egov_law_api_json:407AC0000000039",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "407AC0000000039",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:407AC0000000039"
+        }
+      ]
+    },
+    {
+      "tax_id": "utility-tunnel-planned-occupant-construction-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-03",
+      "reuse_group": "egov_law_api_json:407AC0000000039",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "407AC0000000039",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:407AC0000000039"
+        }
+      ]
+    },
+    {
+      "tax_id": "water-and-land-benefit-tax",
+      "official_name": "水利地益税",
+      "burden_type": "local_tax",
+      "implementation_issue": 43,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-43-common-source-01",
+      "reuse_group": "egov_law_api_json:325AC0000000226",
+      "municipal_scope": "issue_20",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "325AC0000000226",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:325AC0000000226"
+        }
+      ]
+    },
+    {
+      "tax_id": "water-resources-facility-user-charge",
+      "official_name": "unknown",
+      "burden_type": "burden_charge",
+      "implementation_issue": 45,
+      "implementation_status": "planned",
+      "priority": "medium",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-45-batch-03",
+      "reuse_group": "egov_law_api_json:414AC0000000182",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "414AC0000000182",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:414AC0000000182"
+        }
+      ]
+    },
+    {
+      "tax_id": "workers-compensation-insurance-premium",
+      "official_name": "労災保険料",
+      "burden_type": "social_insurance_premium",
+      "implementation_issue": 44,
+      "implementation_status": "planned",
+      "priority": "high",
+      "depends_on_issues": [
+        31
+      ],
+      "batch_id": "issue-44-batch-01",
+      "reuse_group": "egov_law_api_json:322AC0000000050",
+      "municipal_scope": "national_only",
+      "capabilities": {
+        "liable_party": "needs_source_research",
+        "taxable_scope": "needs_source_research",
+        "calculation_basis": "needs_source_research",
+        "rate_or_amount": "needs_source_research",
+        "applicable_period": "needs_source_research"
+      },
+      "sources": [
+        {
+          "source_id": "egov-laws",
+          "target_id": "322AC0000000050",
+          "official_format": "egov_law_api_json",
+          "current_adapter": "manual",
+          "required_adapter": "egov_law_semantics",
+          "adapter_status": "planned",
+          "reuse_key": "egov_law_api_json:322AC0000000050"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/monitoring-configuration.md
+++ b/docs/monitoring-configuration.md
@@ -22,10 +22,26 @@
 
 `npm run monitoring:check`は正本・source設定から監視設定を再構築し、制度追加・削除、source URL、監視区分等の差異を検出する。`npm run validate`は全正本IDとsource IDの参照、重複、必須項目、URL形式を検証する。
 
+## 全制度adapter棚卸し
+
+`config/adapter-inventory.yaml`は正本112制度を重複なく実装先へ割り当てる再生成可能なregistryである。内訳は#39の初号2制度、#42の国税23制度、#43の地方税22制度、#44の社会保険料5制度、#45のその他公的負担60制度となる。消費税・自動車税を含めると国税24制度、地方税23制度を網羅する。
+
+各targetは優先度、依存Issue、batch、共通source再利用キー、自治体範囲、納税義務者・課税対象・算定基礎・率／金額・適用期間の抽出可否を持つ。各公式sourceには`source_id`と`target_id`、形式、現在のadapter、必要な意味抽出adapter、実装状態を記録する。巡回URLは複製せず既存のsource・監視設定から参照する。e-Gov以外の形式は#46の共通形式adapterへも関連付ける。
+
+通常batchは15制度以下とし、20制度を超えるのは同一の共通法令・sourceを再利用する単位だけに限定する。地方税法を共有する地方税22制度がこの例外に該当する。自治体条例と自治体別実税率は引き続き#20で扱う。
+
+```bash
+npm run inventory:generate
+npm run inventory:check
+```
+
+`inventory:check`は`config/monitoring.yaml`から棚卸しを再生成してbyte単位で比較し、未割当、未知target、重複、batch上限違反、地方税の#20分離違反を失敗にする。PR CIでも実行する。
+
 ## 後続工程との責務境界
 
 - #30（PR #38）: 監視元、条文selector、改訂ID・更新日時、対象ノードhashによる変更検知の契約を整備する。納税義務者や税率を意味のある値へ変換する処理は含めない。
 - #39（#19-8）: 消費税と自動車税について、納税義務者、課税対象、課税標準、税率を構造化抽出する。`npm run semantics:check`は縮小fixtureと期待JSONを比較し、`npm run semantics:extract -- --output .cache/semantic-extraction.json`は実APIのレビュー用JSONを生成する。PR CIは前者、定期／手動workflowは後者を実行する。
-- #31（#19-9）: #39の正規化結果を共通pipelineへ接続し、定期監視、PR候補、不確実事項Issueへ連携する。意味抽出規則は再実装しない。
+- #41: 全制度を#39・#42〜#45へ割り当て、形式別共通処理を#46、最終coverage監査を#47へ分離する。
+- #31（#19-9）: #39の正規化結果と#41のregistryを共通pipelineへ接続し、定期監視、PR候補、不確実事項Issueへ連携する。意味抽出規則は再実装しない。
 
-実装順は `#30 → #39 → #31` とする。
+実装順は `#30 → #39 → #41 → #31 → #42〜#46 → #47` とする。

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "initial-master:check": "node scripts/initial-master/build-burdens.js --check",
     "monitoring:generate": "node scripts/monitoring/build-monitoring-config.js",
     "monitoring:check": "node scripts/monitoring/build-monitoring-config.js --check",
+    "inventory:generate": "node scripts/monitoring/build-adapter-inventory.js",
+    "inventory:check": "node scripts/monitoring/build-adapter-inventory.js --check",
     "semantics:extract": "node scripts/monitoring/extract-egov-tax-semantics.js",
     "semantics:check": "node scripts/monitoring/extract-egov-tax-semantics.js --fixture-dir tests/fixtures/source-scan --expected tests/fixtures/semantic-extraction/expected.json"
   },

--- a/schemas/adapter-inventory.schema.json
+++ b/schemas/adapter-inventory.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pirosiki1144/japan-tax-and-public-burden/schemas/adapter-inventory.schema.json",
+  "title": "Semantic adapter implementation inventory",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "generated_at", "batch_policy", "targets"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "batch_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["default_max_targets", "hard_max_targets", "common_source_exception"],
+      "properties": {
+        "default_max_targets": {"const": 15},
+        "hard_max_targets": {"const": 20},
+        "common_source_exception": {"const": "one_common_source_unit"}
+      }
+    },
+    "targets": {"type": "array", "items": {"$ref": "#/$defs/target"}}
+  },
+  "$defs": {
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tax_id", "official_name", "burden_type", "implementation_issue", "implementation_status", "priority", "depends_on_issues", "batch_id", "reuse_group", "municipal_scope", "capabilities", "sources"],
+      "properties": {
+        "tax_id": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
+        "official_name": {"type": "string", "minLength": 1},
+        "burden_type": {"enum": ["national_tax", "local_tax", "social_insurance_premium", "levy", "contribution", "burden_charge", "payment", "adjustment_charge", "insurance_premium", "fee", "other"]},
+        "implementation_issue": {"enum": [39, 42, 43, 44, 45]},
+        "implementation_status": {"enum": ["implemented_initial", "planned"]},
+        "priority": {"enum": ["completed", "high", "medium"]},
+        "depends_on_issues": {"type": "array", "uniqueItems": true, "items": {"enum": [31, 46]}},
+        "batch_id": {"type": "string", "pattern": "^issue-[0-9]+-[a-z0-9]+(?:-[a-z0-9]+)*$"},
+        "reuse_group": {"type": "string", "minLength": 1},
+        "municipal_scope": {"enum": ["national_only", "issue_20"]},
+        "capabilities": {"$ref": "#/$defs/capabilities"},
+        "sources": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/source"}}
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["liable_party", "taxable_scope", "calculation_basis", "rate_or_amount", "applicable_period"],
+      "properties": {
+        "liable_party": {"$ref": "#/$defs/capability"},
+        "taxable_scope": {"$ref": "#/$defs/capability"},
+        "calculation_basis": {"$ref": "#/$defs/capability"},
+        "rate_or_amount": {"$ref": "#/$defs/capability"},
+        "applicable_period": {"$ref": "#/$defs/capability"}
+      }
+    },
+    "capability": {"enum": ["implemented", "planned", "needs_source_research", "not_applicable"]},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_id", "target_id", "official_format", "current_adapter", "required_adapter", "adapter_status", "reuse_key"],
+      "properties": {
+        "source_id": {"type": "string", "minLength": 1},
+        "target_id": {"type": "string", "minLength": 1},
+        "official_format": {"enum": ["egov_law_api_json", "html", "pdf", "csv", "spreadsheet"]},
+        "current_adapter": {"type": "string", "minLength": 1},
+        "required_adapter": {"enum": ["egov_law_semantics", "html_semantics", "pdf_semantics", "csv_semantics", "spreadsheet_semantics"]},
+        "adapter_status": {"enum": ["implemented", "planned"]},
+        "reuse_key": {"type": "string", "minLength": 1},
+        "shared_format_issue": {"const": 46}
+      }
+    }
+  }
+}

--- a/scripts/monitoring/build-adapter-inventory.js
+++ b/scripts/monitoring/build-adapter-inventory.js
@@ -1,0 +1,189 @@
+import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readYaml } from "../validate/schema-validator.js";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const outputPath = join(root, "config/adapter-inventory.yaml");
+const DEFAULT_BATCH_SIZE = 15;
+const MAX_BATCH_SIZE = 20;
+
+async function readBurdens(repositoryRoot) {
+  const burdens = [];
+  for (const entry of await readdir(join(repositoryRoot, "data/burdens"), { withFileTypes: true })) {
+    if (!entry.isFile() || !/\.(?:json|ya?ml)$/.test(entry.name)) continue;
+    const document = await readYaml(join(repositoryRoot, "data/burdens", entry.name));
+    burdens.push(...(Array.isArray(document) ? document : [document]));
+  }
+  return burdens;
+}
+
+function implementationIssue(burden) {
+  if (["consumption-tax", "automobile-tax"].includes(burden.tax_id)) return 39;
+  if (burden.burden_type === "national_tax") return 42;
+  if (burden.burden_type === "local_tax") return 43;
+  if (burden.burden_type === "social_insurance_premium") return 44;
+  return 45;
+}
+
+function sourceFormat(url) {
+  const parsed = new URL(url);
+  if (parsed.hostname === "laws.e-gov.go.jp" && parsed.pathname.startsWith("/api/2/law_data/")) return "egov_law_api_json";
+  const extension = extname(parsed.pathname).toLowerCase();
+  if (extension === ".pdf") return "pdf";
+  if (extension === ".csv") return "csv";
+  if ([".xls", ".xlsx", ".ods"].includes(extension)) return "spreadsheet";
+  return "html";
+}
+
+function requiredAdapter(format) {
+  return `${format === "egov_law_api_json" ? "egov_law" : format}_semantics`;
+}
+
+function reuseKey(source) {
+  const format = sourceFormat(source.target_url);
+  return `${format}:${format === "egov_law_api_json" ? source.target_id : new URL(source.target_url).hostname}`;
+}
+
+function capabilityPlan(taxId) {
+  if (taxId === "consumption-tax") return {
+    liable_party: "implemented", taxable_scope: "implemented", calculation_basis: "implemented", rate_or_amount: "implemented", applicable_period: "planned"
+  };
+  if (taxId === "automobile-tax") return {
+    liable_party: "implemented", taxable_scope: "planned", calculation_basis: "planned", rate_or_amount: "implemented", applicable_period: "planned"
+  };
+  return {
+    liable_party: "needs_source_research", taxable_scope: "needs_source_research", calculation_basis: "needs_source_research", rate_or_amount: "needs_source_research", applicable_period: "needs_source_research"
+  };
+}
+
+function assignBatches(targets) {
+  for (const issue of [39, 42, 43, 44, 45]) {
+    const issueTargets = targets.filter((target) => target.implementation_issue === issue);
+    const groups = new Map();
+    for (const target of issueTargets) {
+      const key = target.reuse_group;
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(target);
+    }
+    let batch = [];
+    let sequence = 1;
+    const flush = () => {
+      if (!batch.length) return;
+      const batchId = `issue-${issue}-batch-${String(sequence).padStart(2, "0")}`;
+      batch.forEach((target) => { target.batch_id = batchId; });
+      batch = [];
+      sequence += 1;
+    };
+    for (const group of [...groups.values()].sort((left, right) => left[0].reuse_group.localeCompare(right[0].reuse_group, "en"))) {
+      if (group.length > MAX_BATCH_SIZE) {
+        flush();
+        const batchId = `issue-${issue}-common-source-${String(sequence).padStart(2, "0")}`;
+        group.forEach((target) => { target.batch_id = batchId; });
+        sequence += 1;
+      } else {
+        if (batch.length && batch.length + group.length > DEFAULT_BATCH_SIZE) flush();
+        batch.push(...group);
+      }
+    }
+    flush();
+  }
+}
+
+export async function buildAdapterInventory(repositoryRoot) {
+  const [monitoring, burdens] = await Promise.all([
+    readYaml(join(repositoryRoot, "config/monitoring.yaml")),
+    readBurdens(repositoryRoot)
+  ]);
+  const burdenById = new Map(burdens.map((burden) => [burden.tax_id, burden]));
+  const targets = monitoring.targets.filter(({ enabled }) => enabled).map((monitoringTarget) => {
+    const burden = burdenById.get(monitoringTarget.tax_id);
+    if (!burden) throw new Error(`${monitoringTarget.tax_id}: canonical burden is missing`);
+    const issue = implementationIssue(burden);
+    const sources = monitoringTarget.sources.filter(({ enabled }) => enabled).map((source) => {
+      const format = sourceFormat(source.target_url);
+      return {
+        source_id: source.source_id,
+        target_id: source.target_id,
+        official_format: format,
+        current_adapter: source.adapter,
+        required_adapter: requiredAdapter(format),
+        adapter_status: issue === 39 && format === "egov_law_api_json" ? "implemented" : "planned",
+        reuse_key: reuseKey(source),
+        ...(format === "egov_law_api_json" ? {} : { shared_format_issue: 46 })
+      };
+    });
+    if (!sources.length) throw new Error(`${monitoringTarget.tax_id}: enabled official source is missing`);
+    return {
+      tax_id: burden.tax_id,
+      official_name: burden.official_name,
+      burden_type: burden.burden_type,
+      implementation_issue: issue,
+      implementation_status: issue === 39 ? "implemented_initial" : "planned",
+      priority: issue === 39 ? "completed" : [42, 43, 44].includes(issue) ? "high" : "medium",
+      depends_on_issues: issue === 39 ? [] : [31, ...(sources.some(({ official_format }) => official_format !== "egov_law_api_json") ? [46] : [])],
+      batch_id: "pending",
+      reuse_group: sources.map(({ reuse_key }) => reuse_key).sort().join("+"),
+      municipal_scope: monitoringTarget.municipal_scope,
+      capabilities: capabilityPlan(burden.tax_id),
+      sources
+    };
+  }).sort((left, right) => left.tax_id.localeCompare(right.tax_id, "en"));
+  assignBatches(targets);
+  return {
+    schema_version: 1,
+    generated_at: monitoring.generated_at,
+    batch_policy: { default_max_targets: DEFAULT_BATCH_SIZE, hard_max_targets: MAX_BATCH_SIZE, common_source_exception: "one_common_source_unit" },
+    targets
+  };
+}
+
+export function validateInventoryCoverage(inventory, monitoring) {
+  const errors = [];
+  const enabled = monitoring.targets.filter(({ enabled }) => enabled).map(({ tax_id }) => tax_id).sort();
+  const inventoried = inventory.targets.map(({ tax_id }) => tax_id).sort();
+  if (new Set(inventoried).size !== inventoried.length) errors.push("adapter inventory contains duplicate tax_id values");
+  const missing = enabled.filter((taxId) => !inventoried.includes(taxId));
+  const extra = inventoried.filter((taxId) => !enabled.includes(taxId));
+  if (missing.length) errors.push(`adapter inventory has unassigned targets: ${missing.join(", ")}`);
+  if (extra.length) errors.push(`adapter inventory has unknown targets: ${extra.join(", ")}`);
+  const batches = new Map();
+  for (const target of inventory.targets) {
+    if (!batches.has(target.batch_id)) batches.set(target.batch_id, []);
+    batches.get(target.batch_id).push(target);
+  }
+  for (const [batchId, targets] of batches) {
+    if (targets.length <= MAX_BATCH_SIZE) continue;
+    if (new Set(targets.map(({ reuse_group }) => reuse_group)).size !== 1) errors.push(`${batchId}: ${targets.length} targets exceed the batch limit without one common source`);
+  }
+  for (const target of inventory.targets) {
+    if (target.burden_type === "local_tax" && target.municipal_scope !== "issue_20") errors.push(`${target.tax_id}: local tax municipality scope must remain in Issue #20`);
+  }
+  return errors;
+}
+
+async function run() {
+  const check = process.argv.includes("--check");
+  const inventory = await buildAdapterInventory(root);
+  const monitoring = await readYaml(join(root, "config/monitoring.yaml"));
+  const coverageErrors = validateInventoryCoverage(inventory, monitoring);
+  if (coverageErrors.length) throw new Error(coverageErrors.join("\n"));
+  const content = `${JSON.stringify(inventory, null, 2)}\n`;
+  if (check) {
+    if (await readFile(outputPath, "utf8") !== content) throw new Error("config/adapter-inventory.yaml differs from canonical monitoring targets");
+    console.log(JSON.stringify({ status: "clean", targets: inventory.targets.length, batches: new Set(inventory.targets.map(({ batch_id }) => batch_id)).size }));
+    return;
+  }
+  await mkdir(dirname(outputPath), { recursive: true });
+  const temporary = `${outputPath}.tmp`;
+  await writeFile(temporary, content, "utf8");
+  await rename(temporary, outputPath);
+  console.log(JSON.stringify({ status: "generated", targets: inventory.targets.length }));
+}
+
+if (process.argv[1] && basename(process.argv[1]) === basename(fileURLToPath(import.meta.url))) {
+  run().catch((error) => {
+    console.error(JSON.stringify({ status: "error", error: error.message }));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/validate/repository-validator.js
+++ b/scripts/validate/repository-validator.js
@@ -4,7 +4,7 @@ import { parse } from "csv-parse/sync";
 import { createValidators, readYaml, validateDocument } from "./schema-validator.js";
 import { validateIntegrity } from "./integrity-validator.js";
 
-const SCHEMA_NAMES = ["burden", "initial-master-candidate", "initial-master-selection", "monitoring", "change", "event", "phase", "source", "revenue", "national-burden-ratio", "national-burden-ratio-mapping", "distribution-config"];
+const SCHEMA_NAMES = ["adapter-inventory", "burden", "initial-master-candidate", "initial-master-selection", "monitoring", "change", "event", "phase", "source", "revenue", "national-burden-ratio", "national-burden-ratio-mapping", "distribution-config"];
 
 async function parseCsvFile(path, schema, errors) {
   try {
@@ -37,7 +37,7 @@ export async function validateRepository(root) {
   const schemaPaths = Object.fromEntries(SCHEMA_NAMES.map((name) => [name, join(root, `schemas/${name}.schema.json`)]));
   const schemas = Object.fromEntries(await Promise.all(SCHEMA_NAMES.map(async (name) => [name, JSON.parse(await readFile(schemaPaths[name], "utf8"))])));
   const validators = await createValidators(schemaPaths);
-  const collections = { burdens: [], candidates: [], changes: [], events: [], phases: [], sources: [], revenues: [], mappings: [], ratios: [], distributionConfigs: [], selectionConfigs: [], monitoringTargets: [] };
+  const collections = { adapterInventories: [], burdens: [], candidates: [], changes: [], events: [], phases: [], sources: [], revenues: [], mappings: [], ratios: [], distributionConfigs: [], selectionConfigs: [], monitoringTargets: [] };
 
   async function validateAndCollect(path, schemaName, target, allowArray = true) {
     try {
@@ -66,6 +66,7 @@ export async function validateRepository(root) {
 
   await validateAndCollect(join(root, "config/distribution.yaml"), "distribution-config", "distributionConfigs", false);
   await validateAndCollect(join(root, "config/initial-master-selection.yaml"), "initial-master-selection", "selectionConfigs", false);
+  await validateAndCollect(join(root, "config/adapter-inventory.yaml"), "adapter-inventory", "adapterInventories", false);
   const monitoringPath = join(root, "config/monitoring.yaml");
   try {
     const monitoring = await readYaml(monitoringPath);

--- a/tests/adapter-inventory.test.js
+++ b/tests/adapter-inventory.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { buildAdapterInventory, validateInventoryCoverage } from "../scripts/monitoring/build-adapter-inventory.js";
+import { readYaml } from "../scripts/validate/schema-validator.js";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+async function inputs() {
+  return {
+    inventory: await buildAdapterInventory(root),
+    monitoring: await readYaml(new URL("../config/monitoring.yaml", import.meta.url))
+  };
+}
+
+test("every enabled monitoring target has one deterministic adapter assignment", async () => {
+  const { inventory, monitoring } = await inputs();
+  const tracked = JSON.parse(await readFile(new URL("../config/adapter-inventory.yaml", import.meta.url), "utf8"));
+  assert.deepEqual(tracked, inventory);
+  assert.deepEqual(validateInventoryCoverage(inventory, monitoring), []);
+  assert.equal(inventory.targets.length, 112);
+  assert.equal(new Set(inventory.targets.map(({ tax_id }) => tax_id)).size, 112);
+  assert.deepEqual(Object.fromEntries([39, 42, 43, 44, 45].map((issue) => [issue, inventory.targets.filter(({ implementation_issue }) => implementation_issue === issue).length])), {
+    39: 2, 42: 23, 43: 22, 44: 5, 45: 60
+  });
+});
+
+test("official formats, required adapters, priorities, and dependencies are explicit", async () => {
+  const { inventory } = await inputs();
+  assert.ok(inventory.targets.every(({ priority, capabilities, sources }) => priority && Object.values(capabilities).every(Boolean) && sources.every(({ official_format, required_adapter, reuse_key }) => official_format && required_adapter && reuse_key)));
+  assert.ok(inventory.targets.filter(({ implementation_issue }) => implementation_issue !== 39).every(({ depends_on_issues }) => depends_on_issues.includes(31)));
+  assert.ok(inventory.targets.flatMap(({ sources }) => sources).filter(({ official_format }) => official_format !== "egov_law_api_json").every(({ shared_format_issue }) => shared_format_issue === 46));
+});
+
+test("large batches are permitted only for one common official source", async () => {
+  const { inventory, monitoring } = await inputs();
+  const batches = new Map();
+  for (const target of inventory.targets) {
+    if (!batches.has(target.batch_id)) batches.set(target.batch_id, []);
+    batches.get(target.batch_id).push(target);
+  }
+  const large = [...batches.values()].filter((targets) => targets.length > 20);
+  assert.equal(large.length, 1);
+  assert.equal(new Set(large[0].map(({ reuse_group }) => reuse_group)).size, 1);
+
+  const invalid = structuredClone(inventory);
+  invalid.targets.slice(0, 21).forEach((target) => { target.batch_id = "issue-45-invalid-batch"; });
+  assert.ok(validateInventoryCoverage(invalid, monitoring).some((error) => /exceed the batch limit/.test(error)));
+});
+
+test("missing, duplicate, and municipal-scope mistakes fail coverage validation", async () => {
+  const { inventory, monitoring } = await inputs();
+  const missing = structuredClone(inventory);
+  missing.targets.pop();
+  assert.ok(validateInventoryCoverage(missing, monitoring).some((error) => /unassigned targets/.test(error)));
+
+  const duplicate = structuredClone(inventory);
+  duplicate.targets.push(structuredClone(duplicate.targets[0]));
+  assert.ok(validateInventoryCoverage(duplicate, monitoring).some((error) => /duplicate tax_id/.test(error)));
+
+  const municipality = structuredClone(inventory);
+  municipality.targets.find(({ burden_type }) => burden_type === "local_tax").municipal_scope = "national_only";
+  assert.ok(validateInventoryCoverage(municipality, monitoring).some((error) => /Issue #20/.test(error)));
+});

--- a/tests/repository-validator.test.js
+++ b/tests/repository-validator.test.js
@@ -19,6 +19,7 @@ test("validation workflow runs only for pull requests", async () => {
   const workflow = parse(await readFile(new URL("../.github/workflows/validate.yml", import.meta.url), "utf8"));
   assert.ok(Object.hasOwn(workflow.on, "pull_request"));
   assert.ok(!Object.hasOwn(workflow.on, "push"));
+  assert.ok(workflow.jobs.validate.steps.some(({ run }) => run === "npm run inventory:check"));
   assert.ok(workflow.jobs.validate.steps.some(({ run }) => run === "npm run semantics:check"));
   assert.ok(workflow.jobs.validate.steps.some(({ run }) => run === "npm run generate:check"));
 });


### PR DESCRIPTION
## 概要

正本112制度の全監視targetを、実装Issue・優先度・依存関係・共通source・実装batch・必要adapterへ重複なく割り当てる再生成可能な棚卸しを追加します。

Closes #41
Parent: #19
Depends on: #39 / PR #40
Next: #31, #42〜#47

## 変更内容

- `config/adapter-inventory.yaml`へ112 targetの実装計画を登録
- JSON SchemaでIssue、状態、優先度、依存関係、batch、抽出可否、公式情報形式を検証
- 正本と`config/monitoring.yaml`からbyte-identicalに再生成するコマンドを追加
- 未割当、未知target、重複、batch上限違反、地方税の#20分離違反を検出
- 通常batchを15制度以下、20制度超は同一共通source単位だけに制限
- PR CIへ`npm run inventory:check`を追加
- 巡回URLは棚卸しへ複製せず、既存のsource・監視設定を参照

## 割当結果

| 実装先 | 件数 | 内容 |
| --- | ---: | --- |
| #39 | 2 | 消費税・自動車税の初号実装 |
| #42 | 23 | 残りの国税 |
| #43 | 22 | 残りの地方税（国法レベル） |
| #44 | 5 | 社会保険料・労働保険料 |
| #45 | 60 | その他の公的負担 |

全体は10 batchです。地方税22制度だけは同一の地方税法を共有するため、共通source例外として1 batchにまとめています。自治体条例・自治体別実税率は#20に維持します。e-Gov以外の形式は#46の共通形式adapterへ関連付け、#47で最終coverageを監査します。

## 受け入れ条件

- [x] 有効な112 targetすべてに実装先Issueがある
- [x] targetの重複・未割当をCIで検出できる
- [x] 公式情報形式と必要adapterを記録した
- [x] 優先順位と依存関係を明示した
- [x] 自治体別情報を#20へ分離した
- [x] `npm test`と`npm run validate`が成功した

## 検証

- `npm ci`: 成功、脆弱性0件
- `npm test`: 77/77成功
- `npm run validate`: 成功
- `npm run inventory:check`: 成功（112 targets / 10 batches）
- `npm run monitoring:check`: 成功（112 targets）
- `npm run semantics:check`: 成功
- `npm run generate:check`: 成功
- `git diff --check`: 成功

## データ影響・不確実な点

- 制度の事実値、税率、正本データは変更しません。
- 未実装制度の5抽出項目は推測せず`needs_source_research`としました。
- 一部の正本制度名が既に`unknown`のものはそのまま保持し、このIssueでは推測補完しません。
- 実際の条文・抽出可否は#42〜#46の制度別調査で確定します。
- 正本自動更新、`main`直接push、自動mergeは行いません。
