### PR TITLE
Issue #47: 全制度adapter coverageをmatrix監査

### DIFF
--- a/.github/workflows/source-scan.yml
+++ b/.github/workflows/source-scan.yml
@@ -13,7 +13,55 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  coverage-plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - id: plan
+        run: echo "matrix=$(npm run --silent audit:coverage -- --matrix)" >> "$GITHUB_OUTPUT"
+      - run: npm run audit:coverage -- --output .cache/adapter-coverage-all.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: adapter-coverage-summary
+          path: .cache/adapter-coverage-all.json
+          if-no-files-found: error
+
+  coverage-audit:
+    needs: coverage-plan
+    strategy:
+      fail-fast: false
+      matrix:
+        batch: ${{ fromJSON(needs.coverage-plan.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run audit:coverage -- --batch "${{ matrix.batch }}" --output ".cache/adapter-coverage-${{ matrix.batch }}.json"
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: adapter-coverage-${{ matrix.batch }}
+          path: .cache/adapter-coverage-${{ matrix.batch }}.json
+          if-no-files-found: error
+
   scan:
+    needs: coverage-audit
+    if: always()
     runs-on: ubuntu-latest
     outputs:
       has_changes: ${{ steps.scan.outputs.has_changes }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,7 @@ jobs:
       - run: npm test
       - run: npm run validate
       - run: npm run inventory:check
+      - run: npm run audit:coverage
       - run: npm run semantics:check
       - run: npm run monitor:check
       - run: npm run generate:check

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "semantics:baseline": "node scripts/monitoring/write-semantic-baseline.js",
     "prepare-update": "node scripts/automation/prepare-update.js",
     "audit": "node scripts/audit/audit-repository.js",
+    "audit:coverage": "node scripts/audit/adapter-coverage-audit.js",
     "audit:scan": "node scripts/audit/audit-source-scan.js",
     "audit:issues": "node scripts/audit/publish-audit-issues.js",
     "generate": "node scripts/generate/generate-distribution.js && node scripts/generate/initial-master-selection.js",

--- a/scripts/audit/adapter-coverage-audit.js
+++ b/scripts/audit/adapter-coverage-audit.js
@@ -1,0 +1,90 @@
+import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readYaml } from "../validate/schema-validator.js";
+import { validateInventoryCoverage } from "../monitoring/build-adapter-inventory.js";
+
+async function exists(path) {
+  try { await access(path); return true; } catch { return false; }
+}
+
+export async function auditAdapterCoverage(root, { batchId } = {}) {
+  const [inventory, monitoring, sources] = await Promise.all([
+    readYaml(join(root, "config/adapter-inventory.yaml")),
+    readYaml(join(root, "config/monitoring.yaml")),
+    readYaml(join(root, "config/sources.yaml"))
+  ]);
+  const errors = validateInventoryCoverage(inventory, monitoring);
+  const sourceById = new Map(sources.sources.map((source) => [source.source_id, source]));
+  const monitoringById = new Map(monitoring.targets.map((target) => [target.tax_id, target]));
+  const targets = batchId ? inventory.targets.filter(({ batch_id: id }) => id === batchId) : inventory.targets;
+  if (batchId && targets.length === 0) errors.push(`${batchId}: batch is missing`);
+
+  const rows = [];
+  for (const target of targets) {
+    const implementedSources = target.sources.filter(({ adapter_status }) => adapter_status === "implemented");
+    const heldSources = target.sources.filter(({ adapter_status }) => adapter_status === "held");
+    if (target.implementation_status === "implemented" && implementedSources.length === 0) errors.push(`${target.tax_id}: implemented target has no implemented source`);
+    if (target.implementation_status === "held" && heldSources.length === 0) errors.push(`${target.tax_id}: manual target has no held source`);
+    for (const source of heldSources) if (!source.hold_reason || source.hold_reason.length < 20) errors.push(`${target.tax_id}/${source.target_id}: manual reason is missing`);
+    for (const source of implementedSources) {
+      if (source.official_format === "egov_law_api_json") continue;
+      const configured = sourceById.get(source.source_id);
+      if (!configured) { errors.push(`${target.tax_id}/${source.source_id}: source registry entry is missing`); continue; }
+      for (const url of configured.entry_urls) {
+        const fixture = join(root, "tests/fixtures/source-scan", basename(new URL(url).pathname));
+        if (!await exists(fixture)) errors.push(`${target.tax_id}/${source.source_id}: fixture is missing for ${basename(new URL(url).pathname)}`);
+      }
+    }
+    rows.push({
+      tax_id: target.tax_id,
+      batch_id: target.batch_id,
+      municipal_scope: target.municipal_scope,
+      monitoring_mode: monitoringById.get(target.tax_id)?.monitoring_mode,
+      implementation_status: target.implementation_status,
+      source_statuses: target.sources.map(({ source_id, adapter_status }) => ({ source_id, adapter_status }))
+    });
+  }
+  const batches = [...new Set(inventory.targets.map(({ batch_id }) => batch_id))].sort().map((id) => {
+    const members = inventory.targets.filter(({ batch_id }) => batch_id === id);
+    const reuseGroups = new Set(members.map(({ reuse_group }) => reuse_group)).size;
+    return { batch_id: id, targets: members.length, implemented: members.filter(({ implementation_status }) => implementation_status.startsWith("implemented")).length, manual: members.filter(({ implementation_status }) => implementation_status === "held").length, reuse_groups: reuseGroups, within_policy: members.length <= inventory.batch_policy.hard_max_targets || reuseGroups === 1 };
+  });
+  return {
+    schema_version: 1,
+    status: errors.length ? "error" : "clean",
+    generated_at: inventory.generated_at,
+    scope: batchId ?? "all",
+    summary: {
+      targets: rows.length,
+      total_targets: inventory.targets.length,
+      automated: rows.filter(({ monitoring_mode }) => monitoring_mode === "automated").length,
+      manual: rows.filter(({ monitoring_mode }) => monitoring_mode === "manual").length,
+      implemented_adapters: rows.filter(({ implementation_status }) => implementation_status.startsWith("implemented")).length,
+      held_adapters: rows.filter(({ implementation_status }) => implementation_status === "held").length,
+      issue_20: rows.filter(({ municipal_scope }) => municipal_scope === "issue_20").length,
+      batches: batchId ? 1 : batches.length
+    },
+    batches: batchId ? batches.filter(({ batch_id }) => batch_id === batchId) : batches,
+    targets: rows,
+    errors
+  };
+}
+
+async function writeJson(path, value) {
+  await mkdir(dirname(path), { recursive: true });
+  const temporary = `${path}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await rename(temporary, path);
+}
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const args = process.argv.slice(2);
+const option = (name) => { const index = args.indexOf(`--${name}`); return index < 0 ? undefined : args[index + 1]; };
+if (process.argv[1] && basename(process.argv[1]) === basename(fileURLToPath(import.meta.url))) {
+  const report = await auditAdapterCoverage(root, { batchId: option("batch") });
+  if (option("output")) await writeJson(option("output"), report);
+  if (args.includes("--matrix")) console.log(JSON.stringify(report.batches.map(({ batch_id }) => batch_id)));
+  else console.log(JSON.stringify({ status: report.status, ...report.summary, errors: report.errors }));
+  if (report.status === "error") process.exitCode = 1;
+}

--- a/scripts/monitoring/build-adapter-inventory.js
+++ b/scripts/monitoring/build-adapter-inventory.js
@@ -190,6 +190,11 @@ export function validateInventoryCoverage(inventory, monitoring) {
   }
   for (const target of inventory.targets) {
     if (target.burden_type === "local_tax" && target.municipal_scope !== "issue_20") errors.push(`${target.tax_id}: local tax municipality scope must remain in Issue #20`);
+    const implemented = target.sources.filter(({ adapter_status: status }) => status === "implemented");
+    const held = target.sources.filter(({ adapter_status: status }) => status === "held");
+    if (target.implementation_status === "implemented" && implemented.length === 0) errors.push(`${target.tax_id}: implemented target has no implemented source`);
+    if (target.implementation_status === "held" && held.length === 0) errors.push(`${target.tax_id}: manual target has no held source`);
+    for (const source of held) if (!source.hold_reason || source.hold_reason.length < 20) errors.push(`${target.tax_id}/${source.target_id}: manual reason is missing`);
   }
   return errors;
 }

--- a/tests/adapter-coverage-audit.test.js
+++ b/tests/adapter-coverage-audit.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { auditAdapterCoverage } from "../scripts/audit/adapter-coverage-audit.js";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+test("all targets produce one reviewable coverage row with bounded batches", async () => {
+  const report = await auditAdapterCoverage(root);
+  assert.equal(report.status, "clean");
+  assert.equal(report.summary.targets, 112);
+  assert.equal(report.summary.total_targets, 112);
+  assert.equal(report.summary.automated + report.summary.manual, 112);
+  assert.equal(report.summary.automated, 10);
+  assert.equal(report.summary.manual, 102);
+  assert.equal(report.summary.implemented_adapters + report.summary.held_adapters, 112);
+  assert.equal(new Set(report.targets.map(({ tax_id }) => tax_id)).size, 112);
+  assert.equal(report.batches.length, 10);
+  assert.ok(report.batches.every(({ within_policy }) => within_policy));
+  assert.ok(report.batches.filter(({ targets }) => targets > 20).every(({ reuse_groups }) => reuse_groups === 1));
+  assert.ok(report.targets.filter(({ municipal_scope }) => municipal_scope === "issue_20").every(({ implementation_status }) => implementation_status));
+});
+
+test("each matrix batch has complete classifications and preserves the global total", async () => {
+  const all = await auditAdapterCoverage(root);
+  const reports = await Promise.all(all.batches.map(({ batch_id }) => auditAdapterCoverage(root, { batchId: batch_id })));
+  assert.ok(reports.every(({ status, summary }) => status === "clean" && summary.batches === 1));
+  assert.equal(reports.reduce((sum, { summary }) => sum + summary.targets, 0), 112);
+  assert.deepEqual(reports.flatMap(({ targets }) => targets.map(({ tax_id }) => tax_id)).toSorted(), all.targets.map(({ tax_id }) => tax_id).toSorted());
+});

--- a/tests/adapter-inventory.test.js
+++ b/tests/adapter-inventory.test.js
@@ -92,3 +92,16 @@ test("missing, duplicate, and municipal-scope mistakes fail coverage validation"
   municipality.targets.find(({ burden_type }) => burden_type === "local_tax").municipal_scope = "national_only";
   assert.ok(validateInventoryCoverage(municipality, monitoring).some((error) => /Issue #20/.test(error)));
 });
+
+test("implemented assignments and manual reasons cannot silently disappear", async () => {
+  const { inventory, monitoring } = await inputs();
+  const implemented = structuredClone(inventory);
+  const implementedTarget = implemented.targets.find(({ implementation_status }) => implementation_status === "implemented");
+  implementedTarget.sources.forEach((source) => { source.adapter_status = "held"; source.hold_reason = "根拠付きmanualへ移行するための一時的な確認理由を記録する"; });
+  assert.ok(validateInventoryCoverage(implemented, monitoring).some((error) => /implemented target has no implemented source/.test(error)));
+
+  const manual = structuredClone(inventory);
+  const manualTarget = manual.targets.find(({ implementation_status }) => implementation_status === "held");
+  delete manualTarget.sources.find(({ adapter_status }) => adapter_status === "held").hold_reason;
+  assert.ok(validateInventoryCoverage(manual, monitoring).some((error) => /manual reason is missing/.test(error)));
+});

--- a/tests/repository-validator.test.js
+++ b/tests/repository-validator.test.js
@@ -49,6 +49,12 @@ test("source scan workflow is fixed, scheduled, and manually runnable", async ()
   assert.ok(scanCommands.some((command) => command.includes("npm run audit")));
   assert.ok(scanCommands.some((command) => command.includes("npm run monitor")));
   assert.ok(scanCommands.some((command) => command.includes("npm run audit:scan")));
+  assert.equal(workflow.jobs["coverage-audit"].strategy["fail-fast"], false);
+  assert.match(workflow.jobs["coverage-audit"].strategy.matrix.batch, /fromJSON/);
+  assert.equal(workflow.jobs.scan.needs, "coverage-audit");
+  assert.equal(workflow.jobs.scan.if, "always()");
+  assert.ok(workflow.jobs["coverage-plan"].steps.some(({ run }) => run?.includes("audit:coverage")));
+  assert.ok(workflow.jobs["coverage-audit"].steps.some(({ uses }) => uses === "actions/upload-artifact@v4"));
   assert.ok(updateCommands.some((command) => command.includes("npm run prepare-update")));
   assert.ok(updateCommands.some((command) => command.includes("npm run generate") && command.includes("git add data generated")));
   assert.ok(updateCommands.some((command) => command.includes("gh pr list") && command.includes("gh pr edit") && command.includes("gh pr create")));

--- a/tests/repository-validator.test.js
+++ b/tests/repository-validator.test.js
@@ -20,6 +20,7 @@ test("validation workflow runs only for pull requests", async () => {
   assert.ok(Object.hasOwn(workflow.on, "pull_request"));
   assert.ok(!Object.hasOwn(workflow.on, "push"));
   assert.ok(workflow.jobs.validate.steps.some(({ run }) => run === "npm run inventory:check"));
+  assert.ok(workflow.jobs.validate.steps.some(({ run }) => run === "npm run audit:coverage"));
   assert.ok(workflow.jobs.validate.steps.some(({ run }) => run === "npm run semantics:check"));
   assert.ok(workflow.jobs.validate.steps.some(({ run }) => run === "npm run monitor:check"));
   assert.ok(workflow.jobs.validate.steps.some(({ run }) => run === "npm run generate:check"));


### PR DESCRIPTION
Closes #47
Parent: #19
Related: #20, #31, #45, #62

## 概要
全112監視targetについて、監視方式、adapter実装状態、source、fixture、manual理由、batch境界を機械監査し、既存の固定source-scan workflow内で10 batchのmatrix artifactを作成するようにしました。別workflowは追加していません。

## 監査結果
- 全target: 112
- 自動監視: 10
- manual監視: 102
- 実装済みadapter: 40
- held adapter: 72
- batch: 10
- #20境界の地方税: 23
- 未割当、重複、manual理由欠落、fixture欠落: 0

## 実装内容
- `npm run audit:coverage` を追加し、全件またはbatch別のレビュー可能JSONを出力
- 実装済みtargetに実装sourceがない状態、manual targetにheld sourceや具体的理由がない状態をCI失敗化
- 非e-Gov実装sourceのfixture欠落を検出
- 10 batchを動的matrixへ展開し、`fail-fast: false`で独立監査
- batch別artifactと全体summary artifactを保存
- 1 batchが失敗しても、他batchと既存#31 source scanを`always()`で継続
- 23件の地方税を#20対象のまま保持
- 20件超batchは単一共通source例外だけ許可

## 変更前・変更後
- 変更前: 全件実行結果artifactはあるが、batch別coverage、fixture欠落、manual根拠欠落をレビューできるmatrix監査がない
- 変更後: 全体summaryと10 batch個別JSONから、全112件の分類と失敗箇所を確認可能

## 検証
- `npm ci --cache /tmp/issue47-npm-cache`: 成功、脆弱性0件
- `npm test`: 122件成功
- `npm run validate`: 成功
- `npm run monitoring:check`: clean
- `npm run inventory:check`: clean
- `npm run generate:check`: clean
- `npm run monitor:check`: no_change、112 targets、31 semantic jobs、findings 0
- `npm run audit:coverage`: clean

## 影響範囲
- 既存 `.github/workflows/source-scan.yml` の前段coverage監査
- adapter inventory coverage検証
- coverage report CLIとCIテスト

## 不確実な点・残件
- manual 102件は未対応を黙認した件数ではなく、設定に公式source・根拠不足・解除条件を保持する運用分類
- #62の残件は本監査で分類漏れがないことを確認した上で、個別の解除条件が満たされた時点で順次更新する
- 自治体別実率・条例は#20の範囲であり、この監査へ混入させない