### PR TITLE
#72 Ports・Strategy registry・composition rootを導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ reports/      生成レポート
 - `data/candidates` は初期マスタへ昇格する前の調査候補です。Schema検証とGitレビューの対象ですが、確定制度マスタや配布対象として扱いません。適合性と昇格条件は[初期マスタ候補のSchema適合性確認](docs/initial-master-schema-fit.md)、税以外の候補の収集範囲は[税以外の公的負担候補の収集・照合](docs/public-burden-candidate-reconciliation.md)、統合判定は[初期マスタ投入対象の統合判定](docs/initial-master-selection.md)を参照してください。
 - 取得途中のHTML、PDF、API応答等は `.cache/` 配下の一時データとし、正本にせずGitにも保存しません。保存が必要な根拠は別Issueで対象と形式をレビューします。
 - 公式HTML・PDF・CSVは `scripts/formats/official-document.js` で原文バイトから形式検証・共通表現化し、制度固有の意味抽出規則は別の設定またはnormalize層へ置きます。共通表現は公式URL、取得日時、原文SHA-256、文書版を保持します。PDFの読取不能、CSVの必須列不足、HTMLの本文欠落、意味抽出の0件・複数件一致は構造変更として失敗させます。PR CIは縮小fixtureだけを使用して外部通信せず、実URLへの疎通は固定の定期・手動workflowで行います。
+- `scripts/application` は具体的なHTTP、PDF、filesystem実装を参照せず、最小Portを通じてsource取得・正規化・差分判定を調整します。`scripts/composition/monitoring-composition.js`を唯一のcomposition rootとし、HTTP source reader、HTML・PDF・CSV document parser、e-Gov・宣言的意味抽出Strategyを登録します。未登録、重複登録、契約外の戻り値は実行前後に失敗させます。
 - 社会保険料の集計関係や公的負担の手動確認情報も監視設定の正本に保持し、制度群別viewは必要な処理の中で決定的に組み立てます。
 - `reports/` や将来の `generated/` は正本から再生成する成果物であり、直接編集しません。
 - 制度の履歴は追記型のeventとphase、およびGit履歴で保持します。既存の事実を上書きして過去の状態を失わないようにします。

--- a/docs/adr/0001-monitoring-architecture-boundaries.md
+++ b/docs/adr/0001-monitoring-architecture-boundaries.md
@@ -31,6 +31,8 @@ cli → application → domain
 
 adapter選択にはStrategy + Registryを使い、依存の組立ては単一composition rootへ集約する。制度固有コードを持たない差は設定で表現し、JavaScriptファイルを追加しない。
 
+#72ではこの決定を、`scripts/application`のI/O非依存な監視処理、用途別の最小Port、`scripts/composition/monitoring-composition.js`の単一composition rootとして実装した。HTTP取得、HTML・PDF・CSV文書変換、e-Gov・宣言的意味抽出は共通のStrategy registry契約へ登録する。既存`pipeline`入口は#73まで互換facadeとして維持し、CLIの全面移動は行わない。
+
 ## 設定の正本
 
 URLの正本は引き続き`config/sources.yaml`とする。制度ごとの監視判断、capability、manual理由、解除条件、再確認方法は、#71で`config/monitoring.yaml`へ統合した。

--- a/reports/architecture-inventory.json
+++ b/reports/architecture-inventory.json
@@ -1,23 +1,24 @@
 {
   "schema_version": 1,
   "scope": "tracked repository files",
-  "baseline_commit": "ed8395f9dc6b02d23816ba07f87d6ca0c7e22e95",
+  "baseline_commit": "2874e9601b3842237d65320d17215451d3b651c7",
   "totals": {
-    "tracked_files": 180,
-    "javascript_files": 68,
-    "import_edges": 102
+    "tracked_files": 184,
+    "javascript_files": 72,
+    "import_edges": 113
   },
   "responsibilities": {
     "adapter": 4,
-    "application": 5,
+    "application": 7,
     "cli": 16,
+    "composition_root": 1,
     "derived_artifact": 10,
     "documentation": 12,
     "domain": 15,
     "fixture": 42,
     "repository_support": 8,
     "source_of_truth": 40,
-    "test": 28
+    "test": 29
   },
   "files": [
     {
@@ -325,6 +326,14 @@
       "responsibility": "source_of_truth"
     },
     {
+      "path": "scripts/application/source-monitoring.js",
+      "responsibility": "application"
+    },
+    {
+      "path": "scripts/application/strategy-registry.js",
+      "responsibility": "application"
+    },
+    {
       "path": "scripts/audit/adapter-coverage-audit.js",
       "responsibility": "cli"
     },
@@ -359,6 +368,10 @@
     {
       "path": "scripts/automation/prepare-update.js",
       "responsibility": "cli"
+    },
+    {
+      "path": "scripts/composition/monitoring-composition.js",
+      "responsibility": "composition_root"
     },
     {
       "path": "scripts/diff/canonical-diff.js",
@@ -737,6 +750,10 @@
       "responsibility": "test"
     },
     {
+      "path": "tests/strategy-registry.test.js",
+      "responsibility": "test"
+    },
+    {
       "path": "tests/tax-candidates.test.js",
       "responsibility": "test"
     }
@@ -744,6 +761,10 @@
   "import_graph": {
     "cycles": [],
     "adjacency": {
+      "scripts/application/source-monitoring.js": [
+        "scripts/application/strategy-registry.js"
+      ],
+      "scripts/application/strategy-registry.js": [],
       "scripts/audit/adapter-coverage-audit.js": [
         "scripts/validate/schema-validator.js",
         "scripts/monitoring/build-monitoring-config.js",
@@ -765,6 +786,20 @@
       "scripts/automation/candidate-update.js": [],
       "scripts/automation/prepare-update.js": [
         "scripts/automation/candidate-update.js"
+      ],
+      "scripts/composition/monitoring-composition.js": [
+        "scripts/application/strategy-registry.js",
+        "scripts/application/source-monitoring.js",
+        "scripts/diff/canonical-diff.js",
+        "scripts/fetch/http-fetcher.js",
+        "scripts/fetch/source-registry.js",
+        "scripts/formats/official-document.js",
+        "scripts/monitoring/extract-egov-tax-semantics.js",
+        "scripts/monitoring/semantic-baseline.js",
+        "scripts/normalize/egov-law-article-facts.js",
+        "scripts/normalize/html-regex-facts.js",
+        "scripts/normalize/normalized-source-validator.js",
+        "scripts/normalize/pdf-regex-facts.js"
       ],
       "scripts/diff/canonical-diff.js": [
         "scripts/validate/schema-validator.js"
@@ -825,12 +860,12 @@
       ],
       "scripts/pipeline/monitoring-pipeline.js": [
         "scripts/audit/source-scan-audit.js",
-        "scripts/monitoring/extract-egov-tax-semantics.js",
         "scripts/monitoring/semantic-baseline.js",
         "scripts/validate/schema-validator.js",
         "scripts/monitoring/build-monitoring-config.js",
         "scripts/monitoring/build-monitoring-execution-plan.js",
-        "scripts/pipeline/source-pipeline.js"
+        "scripts/pipeline/source-pipeline.js",
+        "scripts/composition/monitoring-composition.js"
       ],
       "scripts/pipeline/run-monitoring.js": [
         "scripts/pipeline/monitoring-pipeline.js"
@@ -839,16 +874,11 @@
         "scripts/pipeline/source-pipeline.js"
       ],
       "scripts/pipeline/source-adapters.js": [
-        "scripts/normalize/html-regex-facts.js",
-        "scripts/normalize/egov-law-article-facts.js",
-        "scripts/normalize/pdf-regex-facts.js"
+        "scripts/composition/monitoring-composition.js"
       ],
       "scripts/pipeline/source-pipeline.js": [
-        "scripts/fetch/source-registry.js",
-        "scripts/fetch/http-fetcher.js",
-        "scripts/normalize/normalized-source-validator.js",
-        "scripts/diff/canonical-diff.js",
-        "scripts/pipeline/source-adapters.js"
+        "scripts/application/source-monitoring.js",
+        "scripts/composition/monitoring-composition.js"
       ],
       "scripts/validate/integrity-validator.js": [],
       "scripts/validate/repository-validator.js": [
@@ -890,7 +920,8 @@
       ],
       "tests/format-adapter-registry.test.js": [
         "scripts/validate/schema-validator.js",
-        "scripts/monitoring/build-monitoring-execution-plan.js"
+        "scripts/monitoring/build-monitoring-execution-plan.js",
+        "scripts/composition/monitoring-composition.js"
       ],
       "tests/http-fetcher.test.js": [
         "scripts/fetch/http-fetcher.js"
@@ -962,6 +993,10 @@
         "scripts/audit/source-scan-audit.js",
         "scripts/audit/publish-audit-issues.js"
       ],
+      "tests/strategy-registry.test.js": [
+        "scripts/application/strategy-registry.js",
+        "scripts/composition/monitoring-composition.js"
+      ],
       "tests/tax-candidates.test.js": [
         "scripts/validate/schema-validator.js",
         "data/candidates/local-taxes.yaml"
@@ -985,7 +1020,7 @@
     ]
   },
   "io_duplication": {
-    "filesystem_importing_files": 34,
+    "filesystem_importing_files": 35,
     "atomic_write_implementations": 11,
     "filesystem_users": [
       "scripts/audit/adapter-coverage-audit.js",
@@ -1021,7 +1056,8 @@
       "tests/repository-validator.test.js",
       "tests/schema-naming.test.js",
       "tests/social-insurance-adapters.test.js",
-      "tests/source-pipeline.test.js"
+      "tests/source-pipeline.test.js",
+      "tests/strategy-registry.test.js"
     ],
     "atomic_writers": [
       "scripts/audit/adapter-coverage-audit.js",

--- a/scripts/application/source-monitoring.js
+++ b/scripts/application/source-monitoring.js
@@ -1,0 +1,37 @@
+import { validatePorts } from "./strategy-registry.js";
+
+export async function runSource({ root, sourceId, source: configuredSource, fetchImpl, now = () => new Date(), dryRun = false, ports }) {
+  validatePorts(ports);
+  const source = configuredSource ?? await ports.sourceRepository.loadEnabled(root, sourceId);
+  const normalize = ports.sourceNormalizers.get(source.adapter);
+  const pages = await ports.sourceReader.read(source, { fetchImpl, now });
+  const fetches = pages.map(({ body: _body, bytes: _bytes, ...metadata }) => metadata);
+  try {
+    const normalized = await normalize(source, pages);
+    const candidateDiff = await ports.canonicalRepository.diff(root, normalized);
+    return { schema_version: 1, status: candidateDiff.length === 0 ? "no_change" : "change_detected", dry_run: dryRun, source_id: source.source_id, completed_at: now().toISOString(), fetches, normalized, candidate_diff: candidateDiff };
+  } catch (error) {
+    error.fetches = fetches;
+    error.sourceUrl ??= source.entry_urls[0];
+    throw error;
+  }
+}
+
+export async function runSources({ root, sources, fetchImpl, now = () => new Date(), dryRun = false, ports }) {
+  const results = [];
+  for (const source of sources) {
+    try {
+      results.push(await runSource({ root, sourceId: source.source_id, source, fetchImpl, now, dryRun, ports }));
+    } catch (error) {
+      results.push({ schema_version: 1, status: "error", dry_run: dryRun, source_id: source.source_id, error_code: error.code ?? (error.message.includes("Source structure changed") ? "source_structure_changed" : "source_processing_failed"), error: error.message, retryable: error.retryable ?? false, attempts: error.attempts ?? 1, source_url: error.sourceUrl, fetches: error.fetches });
+    }
+  }
+  return { schema_version: 1, status: results.some(({ status }) => status === "error") ? "error" : results.some(({ status }) => status === "change_detected") ? "change_detected" : "no_change", dry_run: dryRun, completed_at: now().toISOString(), results };
+}
+
+export async function runAllSources(options) {
+  validatePorts(options.ports);
+  const sources = await options.ports.sourceRepository.loadAutomated(options.root);
+  if (sources.length === 0) throw new Error("No enabled automated sources are configured");
+  return runSources({ ...options, sources });
+}

--- a/scripts/application/strategy-registry.js
+++ b/scripts/application/strategy-registry.js
@@ -1,0 +1,58 @@
+function requireFunction(value, label) {
+  if (typeof value !== "function") throw new TypeError(`${label} must be a function`);
+}
+
+export function createStrategyRegistry(kind, validateResult) {
+  requireFunction(validateResult, `${kind} result contract`);
+  const strategies = new Map();
+  return Object.freeze({
+    register(name, strategy) {
+      if (typeof name !== "string" || name.length === 0) throw new TypeError(`${kind} name is required`);
+      requireFunction(strategy, `${kind} ${name}`);
+      if (strategies.has(name)) throw new Error(`Duplicate ${kind}: ${name}`);
+      strategies.set(name, strategy);
+      return this;
+    },
+    has: (name) => strategies.has(name),
+    names: () => [...strategies.keys()].sort(),
+    get(name) {
+      const strategy = strategies.get(name);
+      if (!strategy) throw new Error(`No registered ${kind}: ${name}`);
+      return async (...args) => {
+        const result = await strategy(...args);
+        validateResult(result, name);
+        return result;
+      };
+    }
+  });
+}
+
+export function validateSourcePages(pages, name) {
+  if (!Array.isArray(pages) || pages.length === 0) throw new TypeError(`${name} must return one or more source pages`);
+  for (const page of pages) {
+    if (!page || typeof page !== "object" || !page.source_url || !page.sha256 || (!page.bytes && typeof page.body !== "string")) throw new TypeError(`${name} returned an invalid source page`);
+  }
+}
+
+export function validateDocument(document, name) {
+  if (!document || typeof document !== "object" || !document.format || !document.evidence?.source_url) throw new TypeError(`${name} returned an invalid official document`);
+}
+
+export function validateNormalizedFacts(normalized, name) {
+  if (!normalized || typeof normalized !== "object" || !normalized.source_id || !Array.isArray(normalized.facts)) throw new TypeError(`${name} returned invalid normalized facts`);
+}
+
+export function validateSemanticExtraction(extracted, name) {
+  if (!extracted || typeof extracted !== "object" || !extracted.record || !Array.isArray(extracted.fetches)) throw new TypeError(`${name} returned an invalid semantic extraction`);
+}
+
+export function validatePorts(ports) {
+  for (const [name, method] of [
+    ["sourceRepository.loadEnabled", ports?.sourceRepository?.loadEnabled],
+    ["sourceRepository.loadAutomated", ports?.sourceRepository?.loadAutomated],
+    ["sourceReader.read", ports?.sourceReader?.read],
+    ["canonicalRepository.diff", ports?.canonicalRepository?.diff]
+  ]) requireFunction(method, name);
+  if (typeof ports.sourceNormalizers?.get !== "function") throw new TypeError("sourceNormalizers registry is required");
+  return ports;
+}

--- a/scripts/audit/architecture-inventory.js
+++ b/scripts/audit/architecture-inventory.js
@@ -37,6 +37,8 @@ export function classifyFile(path) {
   if (path.startsWith("scripts/") && CLI_NAMES.test(name)) return "cli";
   if (path.startsWith("scripts/pipeline/") || path.startsWith("scripts/generate/") || path.startsWith("scripts/automation/")) return "application";
   if (path.startsWith("scripts/fetch/") || path.startsWith("scripts/formats/") || path === "scripts/validate/schema-validator.js") return "adapter";
+  if (path.startsWith("scripts/application/")) return "application";
+  if (path.startsWith("scripts/composition/")) return "composition_root";
   if (path.startsWith("scripts/")) return "domain";
   return "unclassified";
 }

--- a/scripts/composition/monitoring-composition.js
+++ b/scripts/composition/monitoring-composition.js
@@ -1,0 +1,42 @@
+import { createStrategyRegistry, validateDocument, validateNormalizedFacts, validateSemanticExtraction, validateSourcePages } from "../application/strategy-registry.js";
+import { runAllSources } from "../application/source-monitoring.js";
+import { detectCanonicalDiff } from "../diff/canonical-diff.js";
+import { fetchSourcePages } from "../fetch/http-fetcher.js";
+import { loadAutomatedSources, loadEnabledSource } from "../fetch/source-registry.js";
+import { adaptCsvDocument, adaptHtmlDocument, adaptPdfDocument } from "../formats/official-document.js";
+import { extractConfiguredSemanticTarget } from "../monitoring/extract-egov-tax-semantics.js";
+import { diffAgainstSemanticBaseline } from "../monitoring/semantic-baseline.js";
+import { normalizeEgovLawArticleFacts } from "../normalize/egov-law-article-facts.js";
+import { normalizeHtmlRegexFacts } from "../normalize/html-regex-facts.js";
+import { validateNormalizedSource } from "../normalize/normalized-source-validator.js";
+import { normalizePdfRegexFacts } from "../normalize/pdf-regex-facts.js";
+
+function buildComposition() {
+  const sourceReaders = createStrategyRegistry("source reader", validateSourcePages).register("http", fetchSourcePages);
+  const documentParsers = createStrategyRegistry("document parser", validateDocument)
+    .register("official_html_document", adaptHtmlDocument)
+    .register("official_pdf_document", adaptPdfDocument)
+    .register("official_csv_document", adaptCsvDocument);
+  const sourceNormalizers = createStrategyRegistry("source normalizer", validateNormalizedFacts)
+    .register("html_regex_facts", (source, pages) => validateNormalizedSource(normalizeHtmlRegexFacts(source, pages)))
+    .register("egov_law_article_facts", (source, pages) => validateNormalizedSource(normalizeEgovLawArticleFacts(source, pages)))
+    .register("pdf_regex_facts", async (source, pages) => validateNormalizedSource(await normalizePdfRegexFacts(source, pages, { parseDocument: documentParsers.get("official_pdf_document") })));
+  const semanticExtractors = createStrategyRegistry("semantic extractor", validateSemanticExtraction)
+    .register("egov_law_semantics", async ({ root, taxId, fetchImpl, now, monitoring, baseline, documentCache }) => {
+      const extracted = await extractConfiguredSemanticTarget(root, taxId, { fetchImpl, now, monitoring, documentCache });
+      return { ...extracted, candidate_diff: diffAgainstSemanticBaseline(extracted.record, baseline) };
+    });
+  const ports = Object.freeze({
+    sourceRepository: Object.freeze({ loadEnabled: loadEnabledSource, loadAutomated: loadAutomatedSources }),
+    sourceReader: Object.freeze({ read: sourceReaders.get("http") }),
+    canonicalRepository: Object.freeze({ diff: detectCanonicalDiff }),
+    sourceNormalizers
+  });
+  return Object.freeze({ ports, registries: Object.freeze({ sourceReaders, documentParsers, sourceNormalizers, semanticExtractors }), runAutomatedSources: (options) => runAllSources({ ...options, ports }) });
+}
+
+let composition;
+export function monitoringComposition() {
+  composition ??= buildComposition();
+  return composition;
+}

--- a/scripts/normalize/pdf-regex-facts.js
+++ b/scripts/normalize/pdf-regex-facts.js
@@ -4,9 +4,9 @@ function compile(pattern, label) {
   try { return new RegExp(pattern); } catch (error) { throw new Error(`Invalid extraction pattern for ${label}: ${error.message}`); }
 }
 
-export async function normalizePdfRegexFacts(source, pages) {
+export async function normalizePdfRegexFacts(source, pages, { parseDocument = adaptPdfDocument } = {}) {
   if (pages.length !== source.extraction.expected_pages) throw new Error(`Source structure changed: expected ${source.extraction.expected_pages} configured pages but found ${pages.length}`);
-  const documents = await Promise.all(pages.map((page) => adaptPdfDocument(page)));
+  const documents = await Promise.all(pages.map((page) => parseDocument(page)));
   const texts = documents.map(({ text }) => text.normalize("NFKC").replace(/\s+/g, ""));
   for (const marker of source.extraction.required_markers) {
     if (!texts[marker.page_index] || !compile(marker.pattern, marker.label).test(texts[marker.page_index])) throw new Error(`Source structure changed: ${marker.label} was not found`);

--- a/scripts/pipeline/monitoring-pipeline.js
+++ b/scripts/pipeline/monitoring-pipeline.js
@@ -1,23 +1,14 @@
 import { join } from "node:path";
 import { auditSourceScan } from "../audit/source-scan-audit.js";
-import { extractConfiguredSemanticTarget } from "../monitoring/extract-egov-tax-semantics.js";
-import { diffAgainstSemanticBaseline, loadSemanticBaseline } from "../monitoring/semantic-baseline.js";
+import { loadSemanticBaseline } from "../monitoring/semantic-baseline.js";
 import { createValidators, readYaml, validateDocument } from "../validate/schema-validator.js";
 import { buildRuntimeMonitoringPlan } from "../monitoring/build-monitoring-config.js";
 import { buildMonitoringExecutionPlan } from "../monitoring/build-monitoring-execution-plan.js";
 import { runAutomatedSources } from "./source-pipeline.js";
-
-const semanticAdapters = new Map([
-  ["egov_law_semantics", async ({ root, taxId, fetchImpl, now, monitoring, baseline, documentCache }) => {
-    const extracted = await extractConfiguredSemanticTarget(root, taxId, { fetchImpl, now, monitoring, documentCache });
-    return { ...extracted, candidate_diff: diffAgainstSemanticBaseline(extracted.record, baseline) };
-  }]
-]);
+import { monitoringComposition } from "../composition/monitoring-composition.js";
 
 export function getSemanticAdapter(name) {
-  const adapter = semanticAdapters.get(name);
-  if (!adapter) throw new Error(`No registered semantic adapter: ${name}`);
-  return adapter;
+  return monitoringComposition().registries.semanticExtractors.get(name);
 }
 
 export async function loadOperationalJobs(root, { batchId } = {}) {

--- a/scripts/pipeline/source-adapters.js
+++ b/scripts/pipeline/source-adapters.js
@@ -1,15 +1,5 @@
-import { normalizeHtmlRegexFacts } from "../normalize/html-regex-facts.js";
-import { normalizeEgovLawArticleFacts } from "../normalize/egov-law-article-facts.js";
-import { normalizePdfRegexFacts } from "../normalize/pdf-regex-facts.js";
-
-const adapters = new Map([
-  ["html_regex_facts", { normalize: normalizeHtmlRegexFacts }],
-  ["egov_law_article_facts", { normalize: normalizeEgovLawArticleFacts }],
-  ["pdf_regex_facts", { normalize: normalizePdfRegexFacts }]
-]);
+import { monitoringComposition } from "../composition/monitoring-composition.js";
 
 export function getSourceAdapter(name) {
-  const adapter = adapters.get(name);
-  if (!adapter) throw new Error(`No implemented adapter: ${name}`);
-  return adapter;
+  return { normalize: monitoringComposition().registries.sourceNormalizers.get(name) };
 }

--- a/scripts/pipeline/source-pipeline.js
+++ b/scripts/pipeline/source-pipeline.js
@@ -1,65 +1,14 @@
-import { loadAutomatedSources, loadEnabledSource } from "../fetch/source-registry.js";
-import { fetchSourcePages } from "../fetch/http-fetcher.js";
-import { validateNormalizedSource } from "../normalize/normalized-source-validator.js";
-import { detectCanonicalDiff } from "../diff/canonical-diff.js";
-import { getSourceAdapter } from "./source-adapters.js";
+import { runAllSources, runSource, runSources } from "../application/source-monitoring.js";
+import { monitoringComposition } from "../composition/monitoring-composition.js";
 
 export async function runSourcePipeline({ root, sourceId, source: configuredSource, fetchImpl, now = () => new Date(), dryRun = false }) {
-  const source = configuredSource ?? await loadEnabledSource(root, sourceId);
-  const adapter = getSourceAdapter(source.adapter);
-  const pages = await fetchSourcePages(source, { fetchImpl, now });
-  const fetches = pages.map(({ body: _body, bytes: _bytes, ...metadata }) => metadata);
-  try {
-    const normalized = validateNormalizedSource(await adapter.normalize(source, pages));
-    const candidateDiff = await detectCanonicalDiff(root, normalized);
-    return {
-      schema_version: 1,
-      status: candidateDiff.length === 0 ? "no_change" : "change_detected",
-      dry_run: dryRun,
-      source_id: source.source_id,
-      completed_at: now().toISOString(),
-      fetches,
-      normalized,
-      candidate_diff: candidateDiff
-    };
-  } catch (error) {
-    error.fetches = fetches;
-    error.sourceUrl ??= source.entry_urls[0];
-    throw error;
-  }
+  return runSource({ root, sourceId, source: configuredSource, fetchImpl, now, dryRun, ports: monitoringComposition().ports });
 }
 
 export async function runAutomatedSources({ root, fetchImpl, now = () => new Date(), dryRun = false }) {
-  const sources = await loadAutomatedSources(root);
-  if (sources.length === 0) throw new Error("No enabled automated sources are configured");
-  return runConfiguredSources({ root, sources, fetchImpl, now, dryRun });
+  return runAllSources({ root, fetchImpl, now, dryRun, ports: monitoringComposition().ports });
 }
 
 export async function runConfiguredSources({ root, sources, fetchImpl, now = () => new Date(), dryRun = false }) {
-  const results = [];
-  for (const source of sources) {
-    try {
-      results.push(await runSourcePipeline({ root, sourceId: source.source_id, source, fetchImpl, now, dryRun }));
-    } catch (error) {
-      results.push({
-        schema_version: 1,
-        status: "error",
-        dry_run: dryRun,
-        source_id: source.source_id,
-        error_code: error.code ?? (error.message.includes("Source structure changed") ? "source_structure_changed" : "source_processing_failed"),
-        error: error.message,
-        retryable: error.retryable ?? false,
-        attempts: error.attempts ?? 1,
-        source_url: error.sourceUrl,
-        fetches: error.fetches
-      });
-    }
-  }
-  return {
-    schema_version: 1,
-    status: results.some(({ status }) => status === "error") ? "error" : results.some(({ status }) => status === "change_detected") ? "change_detected" : "no_change",
-    dry_run: dryRun,
-    completed_at: now().toISOString(),
-    results
-  };
+  return runSources({ root, sources, fetchImpl, now, dryRun, ports: monitoringComposition().ports });
 }

--- a/tests/architecture-inventory.test.js
+++ b/tests/architecture-inventory.test.js
@@ -26,4 +26,6 @@ test("classification keeps canonical configuration separate from generated proje
   assert.equal(classifyFile("config/monitoring.yaml"), "source_of_truth");
   assert.equal(classifyFile("tests/fixtures/source-scan/example.html"), "fixture");
   assert.equal(classifyFile("scripts/pipeline/monitoring-pipeline.js"), "application");
+  assert.equal(classifyFile("scripts/application/source-monitoring.js"), "application");
+  assert.equal(classifyFile("scripts/composition/monitoring-composition.js"), "composition_root");
 });

--- a/tests/format-adapter-registry.test.js
+++ b/tests/format-adapter-registry.test.js
@@ -4,6 +4,7 @@ import { access } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { readYaml } from "../scripts/validate/schema-validator.js";
 import { buildMonitoringExecutionPlan } from "../scripts/monitoring/build-monitoring-execution-plan.js";
+import { monitoringComposition } from "../scripts/composition/monitoring-composition.js";
 
 const root = fileURLToPath(new URL("..", import.meta.url));
 
@@ -13,9 +14,11 @@ test("every inventoried non-e-Gov format has an implementation or a concrete man
     buildMonitoringExecutionPlan(root)
   ]);
   const byFormat = new Map(registry.formats.map((entry) => [entry.format, entry]));
+  const parserRegistry = monitoringComposition().registries.documentParsers;
   assert.deepEqual([...byFormat.keys()].sort(), ["csv", "html", "pdf", "spreadsheet"]);
   for (const entry of registry.formats) {
     if (entry.status === "implemented") {
+      assert.equal(parserRegistry.has(entry.adapter), true);
       await access(`${root}/${entry.implementation}`);
       await access(`${root}/${entry.test_fixture}`);
     } else {

--- a/tests/strategy-registry.test.js
+++ b/tests/strategy-registry.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { createStrategyRegistry } from "../scripts/application/strategy-registry.js";
+import { monitoringComposition } from "../scripts/composition/monitoring-composition.js";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+test("composition root registers every supported source, document, and semantic strategy once", () => {
+  const { registries } = monitoringComposition();
+  assert.deepEqual(registries.sourceReaders.names(), ["http"]);
+  assert.deepEqual(registries.documentParsers.names(), ["official_csv_document", "official_html_document", "official_pdf_document"]);
+  assert.deepEqual(registries.sourceNormalizers.names(), ["egov_law_article_facts", "html_regex_facts", "pdf_regex_facts"]);
+  assert.deepEqual(registries.semanticExtractors.names(), ["egov_law_semantics"]);
+});
+
+test("strategy registry rejects duplicate, missing, and contract-invalid strategies", async () => {
+  const registry = createStrategyRegistry("test strategy", (result, name) => {
+    if (result?.ok !== true) throw new TypeError(`${name} returned an invalid result`);
+  });
+  registry.register("valid", async () => ({ ok: true }));
+  assert.throws(() => registry.register("valid", async () => ({ ok: true })), /Duplicate test strategy/);
+  assert.throws(() => registry.get("missing"), /No registered test strategy/);
+  registry.register("invalid", async () => ({ ok: false }));
+  await assert.rejects(registry.get("invalid")(), /invalid result/);
+  assert.deepEqual(await registry.get("valid")(), { ok: true });
+});
+
+test("application modules do not import concrete I/O or parser implementations", async () => {
+  for (const path of ["scripts/application/source-monitoring.js", "scripts/application/strategy-registry.js"]) {
+    const source = await readFile(`${root}/${path}`, "utf8");
+    assert.doesNotMatch(source, /node:|pdfjs-dist|\.\.\/fetch\/|\.\.\/formats\/|\.\.\/composition\//);
+  }
+});
+
+test("every configured automated source resolves through the composed source normalizer registry", async () => {
+  const { ports, registries } = monitoringComposition();
+  const sources = await ports.sourceRepository.loadAutomated(root);
+  assert.ok(sources.length > 0);
+  assert.deepEqual([...new Set(sources.map(({ adapter }) => adapter).filter((name) => name !== "manual" && !registries.sourceNormalizers.has(name)))], []);
+});


### PR DESCRIPTION
## 関連Issue

Closes #72
Parent: #69
Depends on: #70, #71

## 概要

監視処理の取得・文書変換・意味抽出を最小Portと共通Strategy registryへ統合し、具体実装の組み立てを `scripts/composition/monitoring-composition.js` 一箇所へ集約しました。CLIの全面再配置は#73へ残し、既存pipelineは互換facadeとして維持しています。

## 受け入れ条件の結果

- SourceRepository、SourceReader、CanonicalRepositoryを最小メソッドのPortとしてapplicationへ注入
- HTTP source readerをregistryへ登録
- HTML、PDF、CSV document parserを共通registryへ登録
- e-Gov法令、HTML宣言抽出、PDF宣言抽出のsource normalizerを共通registryへ登録
- e-Gov semantic extractorを同じ契約のregistryへ登録
- adapter選択と依存組み立てを単一composition rootへ集約
- applicationモジュールからNode.js I/O、HTTP、PDF、具体adapterへのimportを排除
- 未登録、重複登録、契約外の戻り値をcontract testで検出
- `config/format-adapters.yaml` の実装済みadapterがcomposition rootに存在することを検証
- 既存pipeline APIとCLIを維持

## 旧値・新値

- 旧: source adapterとsemantic adapterが別々のpipeline内Map・条件分岐で組み立てられる
- 新: source reader、document parser、source normalizer、semantic extractorを一つのcomposition rootで構成
- 旧: source pipelineがfilesystem repository、HTTP fetcher、正本diff実装を直接import
- 新: I/O非依存applicationがPortだけを参照し、互換facadeがcomposition済みPortを渡す

## 互換性・影響範囲

- 現行112制度、automated 10件 / manual 102件、10 batchを維持
- offline監視は112 target、semantic job 31件、結果42件、`no_change`を維持
- 税率、納税対象者、制度状態、公式URL、監視設定の変更なし
- `PROJECT_SPEC.md`は変更なし
- CLI/applicationの全面分離と共通I/Oは#73、Schema/test配置整理は#74で扱う

## 検証

- `npm ci --cache /tmp/jtpb-npm-cache`: 成功、脆弱性0件
- `npm test`: 133件成功、失敗0件
- `npm run validate`: 成功
- `npm run monitoring:check`: clean（112件）
- `npm run monitoring:plan:check`: clean（112件、10 batch）
- `npm run inventory:check`: clean
- `npm run audit:coverage`: clean
- `npm run semantics:check`: 成功
- `npm run monitor:check`: no_change（112 target、31 semantic job）
- `npm run generate:check`: clean
- architecture audit: 184ファイル、循環import 0件

## 不確実な点

- 既存 `scripts/pipeline` は#73まで互換facadeとして残します。
- 新しい抽出機能やadapterは追加していません。
- 本PRはドラフトです。マージは人間レビュー後に判断してください。
