### PR TITLE
#73 CLIとapplication serviceを分離し、共通I/Oを集約

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ reports/      生成レポート
 - 取得途中のHTML、PDF、API応答等は `.cache/` 配下の一時データとし、正本にせずGitにも保存しません。保存が必要な根拠は別Issueで対象と形式をレビューします。
 - 公式HTML・PDF・CSVは `scripts/formats/official-document.js` で原文バイトから形式検証・共通表現化し、制度固有の意味抽出規則は別の設定またはnormalize層へ置きます。共通表現は公式URL、取得日時、原文SHA-256、文書版を保持します。PDFの読取不能、CSVの必須列不足、HTMLの本文欠落、意味抽出の0件・複数件一致は構造変更として失敗させます。PR CIは縮小fixtureだけを使用して外部通信せず、実URLへの疎通は固定の定期・手動workflowで行います。
 - `scripts/application` は具体的なHTTP、PDF、filesystem実装を参照せず、最小Portを通じてsource取得・正規化・差分判定を調整します。`scripts/composition/monitoring-composition.js`を唯一のcomposition rootとし、HTTP source reader、HTML・PDF・CSV document parser、e-Gov・宣言的意味抽出Strategyを登録します。未登録、重複登録、契約外の戻り値は実行前後に失敗させます。
+- scan、monitor、validate、generate、auditのCLIは引数・application呼出し・表示・終了コードだけを担当します。再利用可能なユースケースは`scripts/application`、JSON/YAML検証と原子的ファイル書込みは`scripts/adapters`に置きます。既存のnpmコマンド名とfail-closed動作は維持します。
 - 社会保険料の集計関係や公的負担の手動確認情報も監視設定の正本に保持し、制度群別viewは必要な処理の中で決定的に組み立てます。
 - `reports/` や将来の `generated/` は正本から再生成する成果物であり、直接編集しません。
 - 制度の履歴は追記型のeventとphase、およびGit履歴で保持します。既存の事実を上書きして過去の状態を失わないようにします。

--- a/docs/adr/0001-monitoring-architecture-boundaries.md
+++ b/docs/adr/0001-monitoring-architecture-boundaries.md
@@ -33,6 +33,8 @@ adapter選択にはStrategy + Registryを使い、依存の組立ては単一com
 
 #72ではこの決定を、`scripts/application`のI/O非依存な監視処理、用途別の最小Port、`scripts/composition/monitoring-composition.js`の単一composition rootとして実装した。HTTP取得、HTML・PDF・CSV文書変換、e-Gov・宣言的意味抽出は共通のStrategy registry契約へ登録する。既存`pipeline`入口は#73まで互換facadeとして維持し、CLIの全面移動は行わない。
 
+#73ではscan、monitor、validate、generate、auditをCLIなしで呼べるapplication serviceへ分離し、CLIを引数、呼出し、出力、終了コードへ限定した。JSON読込み、Schemaファイル検証、ディレクトリ作成を伴う原子的書込みは`scripts/adapters`へ集約する。既存npm scriptsの入口は互換性のため維持する。
+
 ## 設定の正本
 
 URLの正本は引き続き`config/sources.yaml`とする。制度ごとの監視判断、capability、manual理由、解除条件、再確認方法は、#71で`config/monitoring.yaml`へ統合した。

--- a/reports/architecture-inventory.json
+++ b/reports/architecture-inventory.json
@@ -1,15 +1,15 @@
 {
   "schema_version": 1,
   "scope": "tracked repository files",
-  "baseline_commit": "2874e9601b3842237d65320d17215451d3b651c7",
+  "baseline_commit": "574f1cdf5cf5ab87e6705ce0e4f2c2f45e8ab781",
   "totals": {
-    "tracked_files": 184,
-    "javascript_files": 72,
-    "import_edges": 113
+    "tracked_files": 188,
+    "javascript_files": 76,
+    "import_edges": 133
   },
   "responsibilities": {
-    "adapter": 4,
-    "application": 7,
+    "adapter": 6,
+    "application": 8,
     "cli": 16,
     "composition_root": 1,
     "derived_artifact": 10,
@@ -18,7 +18,7 @@
     "fixture": 42,
     "repository_support": 8,
     "source_of_truth": 40,
-    "test": 29
+    "test": 30
   },
   "files": [
     {
@@ -324,6 +324,18 @@
     {
       "path": "schemas/source.schema.json",
       "responsibility": "source_of_truth"
+    },
+    {
+      "path": "scripts/adapters/filesystem-store.js",
+      "responsibility": "adapter"
+    },
+    {
+      "path": "scripts/adapters/repository-validation.js",
+      "responsibility": "adapter"
+    },
+    {
+      "path": "scripts/application/repository-operations.js",
+      "responsibility": "application"
     },
     {
       "path": "scripts/application/source-monitoring.js",
@@ -726,6 +738,10 @@
       "responsibility": "test"
     },
     {
+      "path": "tests/repository-operations.test.js",
+      "responsibility": "test"
+    },
+    {
       "path": "tests/repository-validator.test.js",
       "responsibility": "test"
     },
@@ -761,6 +777,15 @@
   "import_graph": {
     "cycles": [],
     "adjacency": {
+      "scripts/adapters/filesystem-store.js": [],
+      "scripts/adapters/repository-validation.js": [
+        "scripts/validate/schema-validator.js"
+      ],
+      "scripts/application/repository-operations.js": [
+        "scripts/audit/repository-audit.js",
+        "scripts/audit/source-scan-audit.js",
+        "scripts/generate/distribution-generator.js"
+      ],
       "scripts/application/source-monitoring.js": [
         "scripts/application/strategy-registry.js"
       ],
@@ -768,22 +793,27 @@
       "scripts/audit/adapter-coverage-audit.js": [
         "scripts/validate/schema-validator.js",
         "scripts/monitoring/build-monitoring-config.js",
-        "scripts/monitoring/build-monitoring-execution-plan.js"
+        "scripts/monitoring/build-monitoring-execution-plan.js",
+        "scripts/adapters/filesystem-store.js"
       ],
       "scripts/audit/architecture-inventory.js": [],
       "scripts/audit/audit-repository.js": [
-        "scripts/validate/repository-validator.js",
-        "scripts/audit/repository-audit.js"
+        "scripts/application/repository-operations.js",
+        "scripts/adapters/filesystem-store.js",
+        "scripts/validate/repository-validator.js"
       ],
       "scripts/audit/audit-source-scan.js": [
-        "scripts/audit/source-scan-audit.js"
+        "scripts/application/repository-operations.js",
+        "scripts/adapters/filesystem-store.js"
       ],
       "scripts/audit/publish-audit-issues.js": [],
       "scripts/audit/repository-audit.js": [
         "scripts/normalize/derive-status.js"
       ],
       "scripts/audit/source-scan-audit.js": [],
-      "scripts/automation/candidate-update.js": [],
+      "scripts/automation/candidate-update.js": [
+        "scripts/adapters/filesystem-store.js"
+      ],
       "scripts/automation/prepare-update.js": [
         "scripts/automation/candidate-update.js"
       ],
@@ -815,18 +845,23 @@
         "scripts/validate/schema-validator.js"
       ],
       "scripts/generate/generate-distribution.js": [
+        "scripts/adapters/filesystem-store.js",
+        "scripts/application/repository-operations.js",
         "scripts/generate/distribution-generator.js"
       ],
       "scripts/generate/initial-master-selection.js": [
-        "scripts/validate/schema-validator.js"
+        "scripts/validate/schema-validator.js",
+        "scripts/adapters/filesystem-store.js"
       ],
       "scripts/initial-master/build-burdens.js": [
         "scripts/generate/initial-master-selection.js",
-        "scripts/validate/schema-validator.js"
+        "scripts/validate/schema-validator.js",
+        "scripts/adapters/filesystem-store.js"
       ],
       "scripts/monitoring/build-monitoring-config.js": [
         "scripts/validate/schema-validator.js",
-        "scripts/monitoring/monitoring-registry.js"
+        "scripts/monitoring/monitoring-registry.js",
+        "scripts/adapters/filesystem-store.js"
       ],
       "scripts/monitoring/build-monitoring-execution-plan.js": [
         "scripts/validate/schema-validator.js",
@@ -847,7 +882,8 @@
         "scripts/validate/schema-validator.js"
       ],
       "scripts/monitoring/write-semantic-baseline.js": [
-        "scripts/monitoring/semantic-baseline.js"
+        "scripts/monitoring/semantic-baseline.js",
+        "scripts/adapters/filesystem-store.js"
       ],
       "scripts/normalize/declarative-document-facts.js": [],
       "scripts/normalize/derive-status.js": [],
@@ -868,10 +904,14 @@
         "scripts/composition/monitoring-composition.js"
       ],
       "scripts/pipeline/run-monitoring.js": [
-        "scripts/pipeline/monitoring-pipeline.js"
+        "scripts/pipeline/monitoring-pipeline.js",
+        "scripts/application/repository-operations.js",
+        "scripts/adapters/filesystem-store.js"
       ],
       "scripts/pipeline/scan-source.js": [
-        "scripts/pipeline/source-pipeline.js"
+        "scripts/pipeline/source-pipeline.js",
+        "scripts/application/repository-operations.js",
+        "scripts/adapters/filesystem-store.js"
       ],
       "scripts/pipeline/source-adapters.js": [
         "scripts/composition/monitoring-composition.js"
@@ -888,7 +928,8 @@
       ],
       "scripts/validate/schema-validator.js": [],
       "scripts/validate/validate-data.js": [
-        "scripts/validate/schema-validator.js",
+        "scripts/application/repository-operations.js",
+        "scripts/adapters/repository-validation.js",
         "scripts/validate/repository-validator.js"
       ],
       "tests/adapter-coverage-audit.test.js": [
@@ -970,6 +1011,9 @@
       "tests/repository-audit.test.js": [
         "scripts/audit/repository-audit.js"
       ],
+      "tests/repository-operations.test.js": [
+        "scripts/application/repository-operations.js"
+      ],
       "tests/repository-validator.test.js": [
         "scripts/validate/repository-validator.js",
         "scripts/validate/schema-validator.js"
@@ -1020,25 +1064,21 @@
     ]
   },
   "io_duplication": {
-    "filesystem_importing_files": 35,
-    "atomic_write_implementations": 11,
+    "filesystem_importing_files": 32,
+    "atomic_write_implementations": 1,
     "filesystem_users": [
+      "scripts/adapters/filesystem-store.js",
       "scripts/audit/adapter-coverage-audit.js",
       "scripts/audit/architecture-inventory.js",
-      "scripts/audit/audit-repository.js",
-      "scripts/audit/audit-source-scan.js",
       "scripts/audit/publish-audit-issues.js",
       "scripts/automation/candidate-update.js",
       "scripts/automation/prepare-update.js",
       "scripts/generate/distribution-generator.js",
-      "scripts/generate/generate-distribution.js",
       "scripts/generate/initial-master-selection.js",
-      "scripts/initial-master/build-burdens.js",
       "scripts/monitoring/build-monitoring-config.js",
       "scripts/monitoring/build-monitoring-execution-plan.js",
       "scripts/monitoring/extract-egov-tax-semantics.js",
       "scripts/monitoring/semantic-baseline.js",
-      "scripts/monitoring/write-semantic-baseline.js",
       "scripts/pipeline/run-monitoring.js",
       "scripts/pipeline/scan-source.js",
       "scripts/validate/repository-validator.js",
@@ -1053,6 +1093,7 @@
       "tests/monitoring-pipeline.test.js",
       "tests/official-document-adapters.test.js",
       "tests/public-burden-adapters.test.js",
+      "tests/repository-operations.test.js",
       "tests/repository-validator.test.js",
       "tests/schema-naming.test.js",
       "tests/social-insurance-adapters.test.js",
@@ -1060,17 +1101,7 @@
       "tests/strategy-registry.test.js"
     ],
     "atomic_writers": [
-      "scripts/audit/adapter-coverage-audit.js",
-      "scripts/audit/audit-repository.js",
-      "scripts/audit/audit-source-scan.js",
-      "scripts/automation/candidate-update.js",
-      "scripts/generate/generate-distribution.js",
-      "scripts/generate/initial-master-selection.js",
-      "scripts/initial-master/build-burdens.js",
-      "scripts/monitoring/build-monitoring-config.js",
-      "scripts/monitoring/write-semantic-baseline.js",
-      "scripts/pipeline/run-monitoring.js",
-      "scripts/pipeline/scan-source.js"
+      "scripts/adapters/filesystem-store.js"
     ]
   },
   "change_surface": {

--- a/scripts/adapters/filesystem-store.js
+++ b/scripts/adapters/filesystem-store.js
@@ -1,0 +1,35 @@
+import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export async function readText(path) {
+  return readFile(path, "utf8");
+}
+
+export async function readJson(path) {
+  return JSON.parse(await readText(path));
+}
+
+export async function listFileNames(path) {
+  return (await readdir(path, { withFileTypes: true })).filter((entry) => entry.isFile()).map(({ name }) => name).sort();
+}
+
+export async function writeTextAtomic(path, content) {
+  await mkdir(dirname(path), { recursive: true });
+  const temporary = `${path}.tmp`;
+  await writeFile(temporary, content, "utf8");
+  await rename(temporary, path);
+}
+
+export function writeJsonAtomic(path, value) {
+  return writeTextAtomic(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export async function readNamedTexts(directory, names) {
+  return new Map(await Promise.all(names.map(async (name) => [name, await readText(join(directory, name))])));
+}
+
+export async function writeNamedTexts(directory, artifacts) {
+  await Promise.all([...artifacts].map(([name, content]) => writeTextAtomic(join(directory, name), content)));
+}
+
+export const filesystemStore = Object.freeze({ readText, readJson, listFileNames, writeTextAtomic, writeJsonAtomic, readNamedTexts, writeNamedTexts });

--- a/scripts/adapters/repository-validation.js
+++ b/scripts/adapters/repository-validation.js
@@ -1,0 +1,9 @@
+import { join } from "node:path";
+import { createValidators, readYaml, validateDocument } from "../validate/schema-validator.js";
+
+export async function validateFile(root, file, schema) {
+  const validators = await createValidators({ [schema]: join(root, `schemas/${schema}.schema.json`) });
+  const parsed = await readYaml(file);
+  const documents = schema !== "source" && Array.isArray(parsed) ? parsed : [parsed];
+  return documents.flatMap((document, index) => validateDocument(validators[schema], document, `${file}[${index}]`));
+}

--- a/scripts/application/repository-operations.js
+++ b/scripts/application/repository-operations.js
@@ -1,0 +1,45 @@
+import { auditRepositoryCollections } from "../audit/repository-audit.js";
+import { auditSourceScan, issueCandidatesFromAudit } from "../audit/source-scan-audit.js";
+import { compareArtifactSets } from "../generate/distribution-generator.js";
+
+export async function validateData({ root, file, schema, validateRepository, validateFile }) {
+  if (!file && !schema) return validateRepository(root);
+  if (!file || !schema) return { errors: ["Both --file and --schema are required."] };
+  try {
+    return { errors: await validateFile(root, file, schema) };
+  } catch (error) {
+    return { errors: [`${file}: ${error.message}`] };
+  }
+}
+
+export async function auditRepository({ root, asOf, now, validateRepository }) {
+  const { errors, collections } = await validateRepository(root);
+  const findings = [...errors.map((message) => ({ severity: "error", code: "schema_or_integrity_error", record_id: null, message })), ...auditRepositoryCollections(collections, { asOf })];
+  return { schema_version: 1, status: findings.some(({ severity }) => severity === "error") ? "error" : findings.length ? "warning" : "clean", generated_at: now().toISOString(), as_of: asOf, summary: { errors: findings.filter(({ severity }) => severity === "error").length, warnings: findings.filter(({ severity }) => severity === "warning").length }, findings };
+}
+
+export function auditScan(scan) {
+  const report = auditSourceScan(scan);
+  report.issue_candidates = issueCandidatesFromAudit(report);
+  return report;
+}
+
+export async function generateDistribution({ root, asOf, outputDirectory, check, buildArtifacts, fileStore }) {
+  const artifacts = await buildArtifacts(root, { asOf });
+  if (check) {
+    const existing = await fileStore.listFileNames(outputDirectory);
+    const differences = compareArtifactSets(artifacts, await fileStore.readNamedTexts(outputDirectory, existing));
+    if (differences.length) throw new Error(`Generated artifacts differ:\n${differences.join("\n")}`);
+    return { status: "clean", files: artifacts.size };
+  }
+  await fileStore.writeNamedTexts(outputDirectory, artifacts);
+  return { status: "generated", files: artifacts.size };
+}
+
+export function scanSources(options) {
+  return options.scanAll ? options.runAll(options) : options.runOne(options);
+}
+
+export function monitorSources(options) {
+  return options.run(options);
+}

--- a/scripts/audit/adapter-coverage-audit.js
+++ b/scripts/audit/adapter-coverage-audit.js
@@ -1,9 +1,10 @@
-import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
+import { access } from "node:fs/promises";
+import { basename, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readYaml } from "../validate/schema-validator.js";
 import { buildRuntimeMonitoringPlan } from "../monitoring/build-monitoring-config.js";
 import { buildMonitoringExecutionPlan, validateExecutionCoverage } from "../monitoring/build-monitoring-execution-plan.js";
+import { writeJsonAtomic } from "../adapters/filesystem-store.js";
 
 async function exists(path) {
   try { await access(path); return true; } catch { return false; }
@@ -72,19 +73,12 @@ export async function auditAdapterCoverage(root, { batchId } = {}) {
   };
 }
 
-async function writeJson(path, value) {
-  await mkdir(dirname(path), { recursive: true });
-  const temporary = `${path}.tmp`;
-  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-  await rename(temporary, path);
-}
-
 const root = fileURLToPath(new URL("../..", import.meta.url));
 const args = process.argv.slice(2);
 const option = (name) => { const index = args.indexOf(`--${name}`); return index < 0 ? undefined : args[index + 1]; };
 if (process.argv[1] && basename(process.argv[1]) === basename(fileURLToPath(import.meta.url))) {
   const report = await auditAdapterCoverage(root, { batchId: option("batch") });
-  if (option("output")) await writeJson(option("output"), report);
+  if (option("output")) await writeJsonAtomic(option("output"), report);
   if (args.includes("--matrix")) console.log(JSON.stringify(report.batches.map(({ batch_id }) => batch_id)));
   else console.log(JSON.stringify({ status: report.status, ...report.summary, errors: report.errors }));
   if (report.status === "error") process.exitCode = 1;

--- a/scripts/audit/architecture-inventory.js
+++ b/scripts/audit/architecture-inventory.js
@@ -36,7 +36,7 @@ export function classifyFile(path) {
   if (path.startsWith(".github/") || [".gitignore", "package.json", "package-lock.json"].includes(path)) return "repository_support";
   if (path.startsWith("scripts/") && CLI_NAMES.test(name)) return "cli";
   if (path.startsWith("scripts/pipeline/") || path.startsWith("scripts/generate/") || path.startsWith("scripts/automation/")) return "application";
-  if (path.startsWith("scripts/fetch/") || path.startsWith("scripts/formats/") || path === "scripts/validate/schema-validator.js") return "adapter";
+  if (path.startsWith("scripts/adapters/") || path.startsWith("scripts/fetch/") || path.startsWith("scripts/formats/") || path === "scripts/validate/schema-validator.js") return "adapter";
   if (path.startsWith("scripts/application/")) return "application";
   if (path.startsWith("scripts/composition/")) return "composition_root";
   if (path.startsWith("scripts/")) return "domain";

--- a/scripts/audit/audit-repository.js
+++ b/scripts/audit/audit-repository.js
@@ -1,8 +1,7 @@
-import { mkdir, rename, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { auditRepository } from "../application/repository-operations.js";
+import { writeJsonAtomic } from "../adapters/filesystem-store.js";
 import { validateRepository } from "../validate/repository-validator.js";
-import { auditRepositoryCollections } from "./repository-audit.js";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
 const args = process.argv.slice(2);
@@ -14,25 +13,8 @@ const output = option("output");
 const asOf = option("as-of") ?? new Date().toISOString().slice(0, 10);
 
 try {
-  const { errors, collections } = await validateRepository(root);
-  const findings = [
-    ...errors.map((message) => ({ severity: "error", code: "schema_or_integrity_error", record_id: null, message })),
-    ...auditRepositoryCollections(collections, { asOf })
-  ];
-  const report = {
-    schema_version: 1,
-    status: findings.some(({ severity }) => severity === "error") ? "error" : findings.length > 0 ? "warning" : "clean",
-    generated_at: new Date().toISOString(),
-    as_of: asOf,
-    summary: { errors: findings.filter(({ severity }) => severity === "error").length, warnings: findings.filter(({ severity }) => severity === "warning").length },
-    findings
-  };
-  if (output) {
-    await mkdir(dirname(output), { recursive: true });
-    const temporary = `${output}.tmp`;
-    await writeFile(temporary, `${JSON.stringify(report, null, 2)}\n`, "utf8");
-    await rename(temporary, output);
-  }
+  const report = await auditRepository({ root, asOf, now: () => new Date(), validateRepository });
+  if (output) await writeJsonAtomic(output, report);
   console.log(JSON.stringify(report));
   if (report.status === "error") process.exitCode = 1;
 } catch (error) {

--- a/scripts/audit/audit-source-scan.js
+++ b/scripts/audit/audit-source-scan.js
@@ -1,6 +1,5 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
-import { auditSourceScan, issueCandidatesFromAudit } from "./source-scan-audit.js";
+import { auditScan } from "../application/repository-operations.js";
+import { readJson, writeJsonAtomic } from "../adapters/filesystem-store.js";
 
 const args = process.argv.slice(2);
 const option = (name) => {
@@ -15,13 +14,8 @@ if (!scanPath || !reportPath) {
   process.exitCode = 2;
 } else {
   try {
-    const scan = JSON.parse(await readFile(scanPath, "utf8"));
-    const report = auditSourceScan(scan);
-    report.issue_candidates = issueCandidatesFromAudit(report);
-    await mkdir(dirname(reportPath), { recursive: true });
-    const temporary = `${reportPath}.tmp`;
-    await writeFile(temporary, `${JSON.stringify(report, null, 2)}\n`, "utf8");
-    await rename(temporary, reportPath);
+    const report = auditScan(await readJson(scanPath));
+    await writeJsonAtomic(reportPath, report);
     console.log(JSON.stringify({ status: report.status, findings: report.findings.length }));
   } catch (error) {
     console.error(JSON.stringify({ status: "error", error: error.message }));

--- a/scripts/automation/candidate-update.js
+++ b/scripts/automation/candidate-update.js
@@ -1,7 +1,8 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { dirname, extname, resolve, sep } from "node:path";
+import { readFile } from "node:fs/promises";
+import { extname, resolve, sep } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { parseDocument } from "yaml";
+import { writeTextAtomic } from "../adapters/filesystem-store.js";
 
 function canonicalPath(root, relativePath) {
   const dataRoot = `${resolve(root, "data")}${sep}`;
@@ -92,9 +93,7 @@ export async function applyCandidateUpdates({ root, scan }) {
 
   for (const [path, document] of documents) {
     const content = document.format === "json" ? `${JSON.stringify(document.value, null, 2)}\n` : document.yaml.toString();
-    const temporary = `${path}.candidate-update.tmp`;
-    await writeFile(temporary, content, "utf8");
-    await rename(temporary, path);
+    await writeTextAtomic(path, content);
   }
   return { changes, applied };
 }
@@ -153,8 +152,5 @@ ${files.map((file) => `- \`${file}\``).join("\n")}
 }
 
 export async function writePullRequestBody(path, body) {
-  await mkdir(dirname(path), { recursive: true });
-  const temporary = `${path}.tmp`;
-  await writeFile(temporary, body, "utf8");
-  await rename(temporary, path);
+  await writeTextAtomic(path, body);
 }

--- a/scripts/generate/generate-distribution.js
+++ b/scripts/generate/generate-distribution.js
@@ -1,7 +1,8 @@
-import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
-import { join, resolve, sep } from "node:path";
+import { resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
-import { buildDistributionArtifacts, compareArtifactSets } from "./distribution-generator.js";
+import { filesystemStore } from "../adapters/filesystem-store.js";
+import { generateDistribution } from "../application/repository-operations.js";
+import { buildDistributionArtifacts } from "./distribution-generator.js";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
 const args = process.argv.slice(2);
@@ -21,24 +22,9 @@ if (!allowedOutput || !outputDirectory.startsWith(allowedRoot)) {
   process.exitCode = 2;
 } else {
   try {
-    const artifacts = await buildDistributionArtifacts(root, { asOf });
-    if (check) {
-      if (requestedOutput !== "generated") throw new Error("--check only supports the tracked generated directory");
-      const existing = (await readdir(outputDirectory, { withFileTypes: true })).filter((entry) => entry.isFile()).map(({ name }) => name).sort();
-      const actual = new Map(await Promise.all(existing.map(async (name) => [name, await readFile(join(outputDirectory, name), "utf8")])));
-      const differences = compareArtifactSets(artifacts, actual);
-      if (differences.length > 0) throw new Error(`Generated artifacts differ:\n${differences.join("\n")}`);
-      console.log(JSON.stringify({ status: "clean", files: artifacts.size }));
-    } else {
-      await mkdir(outputDirectory, { recursive: true });
-      for (const [name, content] of artifacts) {
-        const target = join(outputDirectory, name);
-        const temporary = `${target}.tmp`;
-        await writeFile(temporary, content, "utf8");
-        await rename(temporary, target);
-      }
-      console.log(JSON.stringify({ status: "generated", output_directory: requestedOutput, files: artifacts.size }));
-    }
+    if (check && requestedOutput !== "generated") throw new Error("--check only supports the tracked generated directory");
+    const result = await generateDistribution({ root, asOf, outputDirectory, check, buildArtifacts: buildDistributionArtifacts, fileStore: filesystemStore });
+    console.log(JSON.stringify({ ...result, ...(check ? {} : { output_directory: requestedOutput }) }));
   } catch (error) {
     console.error(JSON.stringify({ status: "error", error: error.message }));
     process.exitCode = 1;

--- a/scripts/generate/initial-master-selection.js
+++ b/scripts/generate/initial-master-selection.js
@@ -1,7 +1,8 @@
-import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readYaml } from "../validate/schema-validator.js";
+import { readText, writeTextAtomic } from "../adapters/filesystem-store.js";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
 const outputPath = join(root, "reports/initial-master-selection.json");
@@ -100,14 +101,11 @@ async function run() {
   const check = process.argv.includes("--check");
   const report = `${JSON.stringify(await buildInitialMasterSelection(root), null, 2)}\n`;
   if (check) {
-    if (await readFile(outputPath, "utf8") !== report) throw new Error("reports/initial-master-selection.json differs from candidate decisions");
+    if (await readText(outputPath) !== report) throw new Error("reports/initial-master-selection.json differs from candidate decisions");
     console.log(JSON.stringify({ status: "clean", candidates: JSON.parse(report).counts.candidates }));
     return;
   }
-  await mkdir(dirname(outputPath), { recursive: true });
-  const temporary = `${outputPath}.tmp`;
-  await writeFile(temporary, report, "utf8");
-  await rename(temporary, outputPath);
+  await writeTextAtomic(outputPath, report);
   console.log(JSON.stringify({ status: "generated", candidates: JSON.parse(report).counts.candidates }));
 }
 

--- a/scripts/initial-master/build-burdens.js
+++ b/scripts/initial-master/build-burdens.js
@@ -1,8 +1,8 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildInitialMasterSelection } from "../generate/initial-master-selection.js";
 import { readYaml } from "../validate/schema-validator.js";
+import { readText, writeTextAtomic } from "../adapters/filesystem-store.js";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
 const outputPath = join(root, "data/burdens/initial-master.json");
@@ -61,14 +61,11 @@ async function run() {
   const check = process.argv.includes("--check");
   const content = `${JSON.stringify(await buildInitialMasterBurdens(root), null, 2)}\n`;
   if (check) {
-    if (await readFile(outputPath, "utf8") !== content) throw new Error("data/burdens/initial-master.json differs from #28 selection");
+    if (await readText(outputPath) !== content) throw new Error("data/burdens/initial-master.json differs from #28 selection");
     console.log(JSON.stringify({ status: "clean", burdens: JSON.parse(content).length }));
     return;
   }
-  await mkdir(dirname(outputPath), { recursive: true });
-  const temporary = `${outputPath}.tmp`;
-  await writeFile(temporary, content, "utf8");
-  await rename(temporary, outputPath);
+  await writeTextAtomic(outputPath, content);
   console.log(JSON.stringify({ status: "generated", burdens: JSON.parse(content).length }));
 }
 

--- a/scripts/monitoring/build-monitoring-config.js
+++ b/scripts/monitoring/build-monitoring-config.js
@@ -1,8 +1,9 @@
-import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readYaml } from "../validate/schema-validator.js";
 import { loadMonitoringRegistry, registryByTaxId } from "./monitoring-registry.js";
+import { readText, writeTextAtomic } from "../adapters/filesystem-store.js";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
 const reviewPath = join(root, "docs/monitoring-extraction-target-review.md");
@@ -170,14 +171,11 @@ async function run() {
   const monitoring = await buildRuntimeMonitoringPlan(root);
   const review = await buildExtractionTargetReview(root);
   if (check) {
-    if (await readFile(reviewPath, "utf8") !== review) throw new Error("monitoring extraction target review differs from canonical burdens");
+    if (await readText(reviewPath) !== review) throw new Error("monitoring extraction target review differs from canonical burdens");
     console.log(JSON.stringify({ status: "clean", targets: monitoring.targets.length, tracked_artifacts: 1 }));
     return;
   }
-  await mkdir(dirname(reviewPath), { recursive: true });
-  const temporaryReview = `${reviewPath}.tmp`;
-  await writeFile(temporaryReview, review, "utf8");
-  await rename(temporaryReview, reviewPath);
+  await writeTextAtomic(reviewPath, review);
   console.log(JSON.stringify({ status: "generated", targets: monitoring.targets.length, tracked_artifacts: 1 }));
 }
 

--- a/scripts/monitoring/write-semantic-baseline.js
+++ b/scripts/monitoring/write-semantic-baseline.js
@@ -1,6 +1,5 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
 import { buildSemanticBaseline } from "./semantic-baseline.js";
+import { readJson, writeJsonAtomic } from "../adapters/filesystem-store.js";
 
 const args = process.argv.slice(2);
 const option = (name) => {
@@ -16,11 +15,8 @@ if (!input || !output || !confirmed) {
   process.exitCode = 2;
 } else {
   try {
-    const baseline = buildSemanticBaseline(JSON.parse(await readFile(input, "utf8")));
-    await mkdir(dirname(output), { recursive: true });
-    const temporary = `${output}.tmp`;
-    await writeFile(temporary, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
-    await rename(temporary, output);
+    const baseline = buildSemanticBaseline(await readJson(input));
+    await writeJsonAtomic(output, baseline);
     console.log(JSON.stringify({ status: "written", records: baseline.records.length, reviewed_at: baseline.reviewed_at }));
   } catch (error) {
     console.error(JSON.stringify({ status: "error", error: error.message }));

--- a/scripts/pipeline/run-monitoring.js
+++ b/scripts/pipeline/run-monitoring.js
@@ -1,7 +1,9 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { basename, dirname, extname, join } from "node:path";
+import { readFile } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runOperationalMonitoring } from "./monitoring-pipeline.js";
+import { monitorSources } from "../application/repository-operations.js";
+import { writeJsonAtomic } from "../adapters/filesystem-store.js";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
 const args = process.argv.slice(2);
@@ -19,13 +21,6 @@ function fixtureFetch(fixtureDir) {
   };
 }
 
-async function writeResult(path, result) {
-  await mkdir(dirname(path), { recursive: true });
-  const temporary = `${path}.tmp`;
-  await writeFile(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
-  await rename(temporary, path);
-}
-
 const output = option("output");
 if (!output) {
   console.error("Usage: node scripts/pipeline/run-monitoring.js --output <result.json> [--fixture-dir <dir>] [--batch <id>] [--dry-run]");
@@ -33,19 +28,19 @@ if (!output) {
 } else {
   try {
     const fixtureDir = option("fixture-dir");
-    const result = await runOperationalMonitoring({
+    const result = await monitorSources({ run: runOperationalMonitoring,
       root,
       fetchImpl: fixtureDir ? fixtureFetch(fixtureDir) : globalThis.fetch,
       dryRun: args.includes("--dry-run"),
       batchId: option("batch"),
       semanticBaselinePath: option("semantic-baseline")
     });
-    await writeResult(output, result);
+    await writeJsonAtomic(output, result);
     console.log(JSON.stringify({ status: result.status, ...result.registry, ...result.routing }));
     if (result.status === "error") process.exitCode = 1;
   } catch (error) {
     const result = { schema_version: 1, status: "error", dry_run: args.includes("--dry-run"), error: error.message, results: [] };
-    await writeResult(output, result);
+    await writeJsonAtomic(output, result);
     console.error(JSON.stringify(result));
     process.exitCode = 1;
   }

--- a/scripts/pipeline/scan-source.js
+++ b/scripts/pipeline/scan-source.js
@@ -1,7 +1,9 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { basename, dirname, extname, join } from "node:path";
+import { readFile } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runAutomatedSources, runSourcePipeline } from "./source-pipeline.js";
+import { scanSources } from "../application/repository-operations.js";
+import { writeJsonAtomic } from "../adapters/filesystem-store.js";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
 const args = process.argv.slice(2);
@@ -23,26 +25,19 @@ async function fixtureFetch(url) {
   return new Response(body, { status: 200, headers: { "content-type": contentType } });
 }
 
-async function writeResult(path, result) {
-  await mkdir(dirname(path), { recursive: true });
-  const temporary = `${path}.tmp`;
-  await writeFile(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
-  await rename(temporary, path);
-}
-
 if ((!sourceId && !scanAll) || (sourceId && scanAll)) {
   console.error("Specify exactly one of --source or --all");
   process.exitCode = 2;
 } else {
   try {
     const options = { root, fetchImpl: fixtureDir ? fixtureFetch : globalThis.fetch, dryRun };
-    const result = scanAll ? await runAutomatedSources(options) : await runSourcePipeline({ ...options, sourceId });
-    if (output) await writeResult(output, result);
+    const result = await scanSources({ ...options, sourceId, scanAll, runAll: runAutomatedSources, runOne: runSourcePipeline });
+    if (output) await writeJsonAtomic(output, result);
     console.log(JSON.stringify(result));
     if (result.status === "error") process.exitCode = 1;
   } catch (error) {
     const result = { schema_version: 1, status: "error", dry_run: dryRun, source_id: sourceId ?? "all", error: error.message };
-    if (output) await writeResult(output, result);
+    if (output) await writeJsonAtomic(output, result);
     console.error(JSON.stringify(result));
     process.exitCode = 1;
   }

--- a/scripts/validate/validate-data.js
+++ b/scripts/validate/validate-data.js
@@ -1,34 +1,15 @@
-import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { createValidators, readYaml, validateDocument } from "./schema-validator.js";
+import { validateData } from "../application/repository-operations.js";
+import { validateFile } from "../adapters/repository-validation.js";
 import { validateRepository } from "./repository-validator.js";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
-let errors = [];
-
 const argumentsMap = Object.fromEntries(process.argv.slice(2).reduce((pairs, value, index, values) => {
   if (value.startsWith("--")) pairs.push([value.slice(2), values[index + 1]]);
   return pairs;
 }, []));
 
-if (argumentsMap.file || argumentsMap.schema) {
-  const schemaName = argumentsMap.schema;
-  const schemaPath = schemaName ? join(root, `schemas/${schemaName}.schema.json`) : null;
-  if (!argumentsMap.file || !schemaPath) {
-    errors.push("Both --file and --schema are required.");
-  } else {
-    try {
-      const validators = await createValidators({ [schemaName]: schemaPath });
-      const parsed = await readYaml(argumentsMap.file);
-      const documents = schemaName !== "source" && Array.isArray(parsed) ? parsed : [parsed];
-      documents.forEach((document, index) => errors.push(...validateDocument(validators[schemaName], document, `${argumentsMap.file}[${index}]`)));
-    } catch (error) {
-      errors.push(`${argumentsMap.file}: ${error.message}`);
-    }
-  }
-} else {
-  ({ errors } = await validateRepository(root));
-}
+const { errors } = await validateData({ root, file: argumentsMap.file, schema: argumentsMap.schema, validateRepository, validateFile });
 
 if (errors.length) {
   console.error(errors.join("\n"));

--- a/tests/architecture-inventory.test.js
+++ b/tests/architecture-inventory.test.js
@@ -18,7 +18,8 @@ test("the baseline inventory detects dependency and configuration duplication", 
   assert.equal(report.configuration_overlap.post_initial_decision_targets, 110);
   assert.deepEqual(report.configuration_overlap.initial_implementation_targets, ["automobile-tax", "consumption-tax"]);
   assert.equal(report.configuration_overlap.manually_edited_decision_files, 1);
-  assert.ok(report.io_duplication.atomic_write_implementations > 1);
+  assert.equal(report.io_duplication.atomic_write_implementations, 1);
+  assert.deepEqual(report.io_duplication.atomic_writers, ["scripts/adapters/filesystem-store.js"]);
 });
 
 test("classification keeps canonical configuration separate from generated projections", () => {

--- a/tests/repository-operations.test.js
+++ b/tests/repository-operations.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { auditRepository, auditScan, generateDistribution, monitorSources, scanSources, validateData } from "../scripts/application/repository-operations.js";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+test("scan and monitor application services are callable without a CLI", async () => {
+  const one = await scanSources({ scanAll: false, marker: 1, runOne: async ({ marker }) => ({ marker }), runAll: async () => null });
+  const all = await scanSources({ scanAll: true, marker: 2, runOne: async () => null, runAll: async ({ marker }) => ({ marker }) });
+  const monitor = await monitorSources({ marker: 3, run: async ({ marker }) => ({ marker }) });
+  assert.deepEqual([one, all, monitor], [{ marker: 1 }, { marker: 2 }, { marker: 3 }]);
+});
+
+test("validation and audit services keep errors explicit", async () => {
+  assert.deepEqual(await validateData({ root, file: "x", validateRepository: async () => ({ errors: [] }) }), { errors: ["Both --file and --schema are required."] });
+  assert.deepEqual(await validateData({ root, validateRepository: async () => ({ errors: ["broken"], collections: {} }) }), { errors: ["broken"], collections: {} });
+  const report = await auditRepository({ root, asOf: "2026-08-28", now: () => new Date("2026-08-28T00:00:00Z"), validateRepository: async () => ({ errors: ["broken"], collections: {} }) });
+  assert.equal(report.status, "error");
+  assert.equal(report.findings[0].code, "schema_or_integrity_error");
+  const scanAudit = auditScan({ schema_version: 1, status: "error", results: [{ source_id: "x", status: "error", error: "failed", fetches: [] }] });
+  assert.equal(scanAudit.status, "needs_review");
+  assert.equal(scanAudit.issue_candidates.length, 1);
+});
+
+test("generation uses an injected atomic file store in write and check modes", async () => {
+  const artifacts = new Map([["a.json", "{}\n"]]);
+  const writes = [];
+  const fileStore = {
+    writeNamedTexts: async (directory, values) => writes.push([directory, values]),
+    listFileNames: async () => ["a.json"],
+    readNamedTexts: async () => artifacts
+  };
+  assert.deepEqual(await generateDistribution({ root, outputDirectory: "/tmp/generated", check: false, buildArtifacts: async () => artifacts, fileStore }), { status: "generated", files: 1 });
+  assert.equal(writes.length, 1);
+  assert.deepEqual(await generateDistribution({ root, outputDirectory: "/tmp/generated", check: true, buildArtifacts: async () => artifacts, fileStore }), { status: "clean", files: 1 });
+});
+
+test("primary CLI files contain only orchestration and no extraction implementation", async () => {
+  for (const path of ["scripts/pipeline/scan-source.js", "scripts/pipeline/run-monitoring.js", "scripts/validate/validate-data.js", "scripts/generate/generate-distribution.js", "scripts/audit/audit-repository.js"]) {
+    const source = await readFile(`${root}/${path}`, "utf8");
+    assert.doesNotMatch(source, /normalize|pdfjs-dist|canonical-diff|auditRepositoryCollections|validateDocument/);
+  }
+});


### PR DESCRIPTION
## 関連Issue

Closes #73
Parent: #69
Depends on: #72 / PR #78

## 概要

scan、monitor、validate、generate、auditの再利用可能なユースケースをapplication serviceへ分離し、CLIを引数解析、service呼出し、表示、終了コードへ限定しました。JSON読込み、Schemaファイル検証、原子的書込みは共通adapterへ集約しています。

## 受け入れ条件の結果

- scan、monitor、validate、generate、auditをCLIなしで呼べるapplication serviceとして公開
- root、時刻、fetch、validator、artifact builder、filesystem storeを明示的に注入
- JSON/text読込みと `write → rename` の原子的書込みを `scripts/adapters/filesystem-store.js` へ集約
- 単一ファイルSchema検証をrepository validation adapterへ分離
- 既存のscan/monitor/validate/generate/audit CLIからdomain・抽出規則を除去
- 初期マスタ、監視レビュー、coverage、baseline、候補更新も共通atomic writerを利用
- atomic write実装を複数箇所から1箇所へ削減
- 既存npm script名と引数を変更せず維持
- workflow追加なし

## 旧値・新値

- 旧: CLIごとにJSON読込み、mkdir、一時ファイル書込み、renameを実装
- 新: 共通filesystem adapterのみに原子的書込みを実装
- 旧: validate、generate、auditのユースケースがCLI制御と混在
- 新: application serviceをテストや他処理から直接呼出可能

## 互換性・fail-closed確認

- 取得失敗、構造変更、未対応差分は従来どおりerrorまたはneeds_reviewへ分離
- offline監視は112 target、31 semantic job、`no_change`を維持
- distribution 6ファイル、initial-master候補119件をbyte差分なしで確認
- 正本データ、税率、対象者、公式URLの変更なし
- `PROJECT_SPEC.md`の変更なし

## 検証

- `npm ci --cache /tmp/jtpb-npm-cache`: 成功、脆弱性0件
- `npm test`: 137件成功、失敗0件
- `npm run validate`: 成功
- `npm run monitoring:check`: clean（112件）
- `npm run monitoring:plan:check`: clean（112件、10 batch）
- `npm run inventory:check`: clean
- `npm run audit:coverage`: clean
- `npm run semantics:check`: 成功
- `npm run monitor:check`: no_change（112 target、31 semantic job）
- `npm run generate:check`: clean
- architecture audit: 188ファイル、循環import 0件、atomic writer 1件

## 不確実な点

- CLIファイルの物理的な移動・test配置の全面整理は#74/#75の範囲とし、本PRでは既存npm入口を維持しました。
- 本PRはドラフトです。マージは人間レビュー後に判断してください。
