### PR TITLE
#82 data・Schema・リポジトリ全体の整合性監査

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ reports/      生成レポート
 - `scripts/application` は具体的なHTTP、PDF、filesystem実装を参照せず、最小Portを通じてsource取得・正規化・差分判定を調整します。`scripts/composition/monitoring-composition.js`を唯一のcomposition rootとし、HTTP source reader、HTML・PDF・CSV document parser、e-Gov・宣言的意味抽出Strategyを登録します。未登録、重複登録、契約外の戻り値は実行前後に失敗させます。
 - scan、monitor、validate、generate、auditのCLIは引数・application呼出し・表示・終了コードだけを担当します。再利用可能なユースケースは`scripts/application`、JSON/YAML検証と原子的ファイル書込みは`scripts/adapters`に置きます。既存のnpmコマンド名とfail-closed動作は維持します。
 - Schemaは永続化・投影境界ごとに維持し、意味と制約が同じID、確認日時、source ID配列、保留理由だけを`schemas/common.schema.json`で再利用します。unit・contract・integration・fixtureの責務と独立維持理由は[Schema・テスト境界](docs/schema-and-test-boundaries.md)を参照してください。
+- `data/`・`config/`とSchema、横断ID、生成物、scripts、workflow、文書の整合性確認は[リポジトリ整合性監査](docs/repository-consistency-audit.md)に記録しています。未登録の永続ファイルは`npm run validate`でエラーになります。
 - #69の構造移行、削除判断、定量比較、112制度の互換性確認は[監視基盤リファクタリング最終監査](docs/refactoring-final-audit.md)に記録しています。
 - 社会保険料の集計関係や公的負担の手動確認情報も監視設定の正本に保持し、制度群別viewは必要な処理の中で決定的に組み立てます。
 - `reports/` や将来の `generated/` は正本から再生成する成果物であり、直接編集しません。

--- a/docs/repository-consistency-audit.md
+++ b/docs/repository-consistency-audit.md
@@ -1,0 +1,21 @@
+# リポジトリ整合性監査
+
+- 対応Issue: #82
+- 監査日: 2026-08-29
+
+`data/`のJSON・YAML・CSVは、永続ファイルとSchemaの対応を`repository-validator`で明示し、未登録ファイルをエラーにする。`config/`の5正本も同じ対応表で管理する。個別ファイルのSchema適合に加え、ID重複、burden・change・event・phase・source・revenue・mapping・monitoring間の参照を検査する。
+
+今回、既存ファイルのSchema不適合、参照切れ、生成物差分は検出されなかった。一方、将来のファイル追加を検証対象へ登録し忘れる余地と、sourceの`monitoring_tax_ids`およびsemantic baselineの`tax_id`が共通参照検査の対象外だった点を検査不足として修正した。
+
+Schemaは永続化境界、実行時projection、配布物、制度群別registry契約に分かれており、用途のないSchemaや参照切れはない。`reports/`と監視レビュー文書は正本から決定的に再生成し、`generate:check`、`architecture:check`、`monitoring:check`で差分を検出する。npm scriptsと2つのworkflowで使うコマンド・パスはcontract testで照合する。
+
+最終確認は次を実行する。
+
+```text
+npm test
+npm run validate
+npm run generate:check
+npm run monitoring:check
+npm run inventory:check
+npm run audit:coverage
+```

--- a/reports/architecture-inventory.json
+++ b/reports/architecture-inventory.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
   "scope": "tracked repository files",
-  "baseline_commit": "702aaca0d03ef48adc8e899c6f3a36a1f034cf4d",
+  "baseline_commit": "553cb9461ad7c7513e5ad3e81a6cb2560eebfdf4",
   "totals": {
-    "tracked_files": 192,
-    "javascript_files": 77,
-    "import_edges": 137
+    "tracked_files": 194,
+    "javascript_files": 78,
+    "import_edges": 139
   },
   "responsibilities": {
     "adapter": 6,
@@ -13,12 +13,12 @@
     "cli": 16,
     "composition_root": 1,
     "derived_artifact": 10,
-    "documentation": 14,
+    "documentation": 15,
     "domain": 15,
     "fixture": 42,
     "repository_support": 8,
     "source_of_truth": 41,
-    "test": 32
+    "test": 33
   },
   "files": [
     {
@@ -187,6 +187,10 @@
     },
     {
       "path": "docs/refactoring-final-audit.md",
+      "responsibility": "documentation"
+    },
+    {
+      "path": "docs/repository-consistency-audit.md",
       "responsibility": "documentation"
     },
     {
@@ -750,6 +754,10 @@
       "responsibility": "test"
     },
     {
+      "path": "tests/repository-consistency.test.js",
+      "responsibility": "test"
+    },
+    {
       "path": "tests/repository-operations.test.js",
       "responsibility": "test"
     },
@@ -1030,6 +1038,10 @@
       "tests/repository-audit.test.js": [
         "scripts/audit/repository-audit.js"
       ],
+      "tests/repository-consistency.test.js": [
+        "scripts/validate/integrity-validator.js",
+        "scripts/validate/repository-validator.js"
+      ],
       "tests/repository-operations.test.js": [
         "scripts/application/repository-operations.js"
       ],
@@ -1087,7 +1099,7 @@
     ]
   },
   "io_duplication": {
-    "filesystem_importing_files": 34,
+    "filesystem_importing_files": 35,
     "atomic_write_implementations": 1,
     "filesystem_users": [
       "scripts/adapters/filesystem-store.js",
@@ -1117,6 +1129,7 @@
       "tests/official-document-adapters.test.js",
       "tests/public-burden-adapters.test.js",
       "tests/refactoring-final-audit.test.js",
+      "tests/repository-consistency.test.js",
       "tests/repository-operations.test.js",
       "tests/repository-validator.test.js",
       "tests/schema-contracts.test.js",

--- a/scripts/validate/integrity-validator.js
+++ b/scripts/validate/integrity-validator.js
@@ -61,6 +61,18 @@ export function validateIntegrity(collections) {
     requireReference(indexes.changes, event.change_id, `${event.event_id}.change_id`, errors);
   }
 
+  for (const source of collections.sources ?? []) {
+    for (const taxId of source.monitoring_tax_ids ?? []) {
+      requireReference(indexes.burdens, taxId, `${source.source_id}.monitoring_tax_ids`, errors);
+    }
+  }
+
+  for (const baseline of collections.semanticBaselines ?? []) {
+    for (const record of baseline.records ?? []) {
+      requireReference(indexes.burdens, record.tax_id, `${record.tax_id}.semantic_baseline.tax_id`, errors);
+    }
+  }
+
   for (const revenue of collections.revenues ?? []) {
     requireReference(indexes.burdens, revenue.tax_id, `${revenue.record_id}.tax_id`, errors);
     validateDateOrder(revenue, "period_start", "period_end", revenue.record_id, errors);

--- a/scripts/validate/repository-validator.js
+++ b/scripts/validate/repository-validator.js
@@ -1,11 +1,38 @@
 import { readdir, readFile } from "node:fs/promises";
-import { extname, join } from "node:path";
+import { extname, join, relative } from "node:path";
 import { parse } from "csv-parse/sync";
 import { createValidators, readYaml, validateDocument } from "./schema-validator.js";
 import { validateIntegrity } from "./integrity-validator.js";
 import { buildRuntimeMonitoringPlan } from "../monitoring/build-monitoring-config.js";
 
 const SCHEMA_NAMES = ["monitoring", "monitoring-runtime", "format-adapters", "semantic-baseline", "burden", "initial-master-candidate", "initial-master-selection", "change", "event", "phase", "source", "revenue", "national-burden-ratio", "national-burden-ratio-mapping", "distribution-config"];
+
+const DIRECTORY_SCHEMA_ROUTES = new Map([
+  ["data/burdens", "burden"],
+  ["data/candidates", "initial-master-candidate"],
+  ["data/changes", "change"],
+  ["data/events", "event"],
+  ["data/phases", "phase"]
+]);
+
+async function persistedFiles(root, directory) {
+  const files = [];
+  for (const entry of await readdir(join(root, directory), { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...await persistedFiles(root, path));
+    else if (entry.name !== ".gitkeep") files.push(path);
+  }
+  return files;
+}
+
+export async function validatePersistedFileCoverage(root, validatedPaths) {
+  const expected = new Set([
+    ...await persistedFiles(root, "config"),
+    ...await persistedFiles(root, "data")
+  ]);
+  const actual = new Set([...validatedPaths].map((path) => relative(root, path)));
+  return [...expected].filter((path) => !actual.has(path)).map((path) => `${path}: no repository schema validation route`);
+}
 
 async function parseCsvFile(path, schema, errors) {
   try {
@@ -35,6 +62,7 @@ async function parseCsvFile(path, schema, errors) {
 
 export async function validateRepository(root) {
   const errors = [];
+  const validatedPaths = new Set();
   const schemaPaths = Object.fromEntries(SCHEMA_NAMES.map((name) => [name, join(root, `schemas/${name}.schema.json`)]));
   const schemas = Object.fromEntries(await Promise.all(SCHEMA_NAMES.map(async (name) => [name, JSON.parse(await readFile(schemaPaths[name], "utf8"))])));
   const validators = await createValidators(schemaPaths);
@@ -50,6 +78,7 @@ export async function validateRepository(root) {
         errors.push(...documentErrors);
         if (documentErrors.length === 0) collections[target].push(document);
       });
+      validatedPaths.add(path);
     } catch (error) {
       errors.push(`${path}: ${error.message}`);
     }
@@ -61,6 +90,7 @@ export async function validateRepository(root) {
     const sourceErrors = validateDocument(validators.source, sourceRegistry, sourcePath);
     errors.push(...sourceErrors);
     if (sourceErrors.length === 0) collections.sources.push(...sourceRegistry.sources);
+    validatedPaths.add(sourcePath);
   } catch (error) {
     errors.push(`${sourcePath}: ${error.message}`);
   }
@@ -80,14 +110,9 @@ export async function validateRepository(root) {
     errors.push(`${monitoringPath}: ${error.message}`);
   }
 
-  for (const [directory, schemaName, target] of [
-    ["burdens", "burden", "burdens"],
-    ["candidates", "initial-master-candidate", "candidates"],
-    ["changes", "change", "changes"],
-    ["events", "event", "events"],
-    ["phases", "phase", "phases"]
-  ]) {
-    const path = join(root, "data", directory);
+  for (const [directory, schemaName] of DIRECTORY_SCHEMA_ROUTES) {
+    const path = join(root, directory);
+    const target = directory.slice("data/".length);
     for (const entry of await readdir(path, { withFileTypes: true })) {
       if (entry.isFile() && [".json", ".yaml", ".yml"].includes(extname(entry.name))) {
         await validateAndCollect(join(path, entry.name), schemaName, target);
@@ -101,6 +126,7 @@ export async function validateRepository(root) {
     const mappingErrors = validateDocument(validators["national-burden-ratio-mapping"], mappingRegistry, mappingPath);
     errors.push(...mappingErrors);
     if (mappingErrors.length === 0) collections.mappings.push(...mappingRegistry.mappings);
+    validatedPaths.add(mappingPath);
   } catch (error) {
     errors.push(`${mappingPath}: ${error.message}`);
   }
@@ -111,6 +137,7 @@ export async function validateRepository(root) {
   ]) {
     const path = join(root, relativePath);
     const records = await parseCsvFile(path, schemas[schemaName], errors);
+    validatedPaths.add(path);
     records.forEach((record, index) => {
       const recordErrors = validateDocument(validators[schemaName], record, `${path}[${index}]`);
       errors.push(...recordErrors);
@@ -119,5 +146,6 @@ export async function validateRepository(root) {
   }
 
   errors.push(...validateIntegrity(collections));
+  errors.push(...await validatePersistedFileCoverage(root, validatedPaths));
   return { errors, collections };
 }

--- a/tests/repository-consistency.test.js
+++ b/tests/repository-consistency.test.js
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { validateIntegrity } from "../scripts/validate/integrity-validator.js";
+import { validatePersistedFileCoverage } from "../scripts/validate/repository-validator.js";
+
+test("every persisted data and config file has an explicit schema route", async () => {
+  const root = new URL("..", import.meta.url).pathname;
+  const validated = new Set([
+    join(root, "config/distribution.yaml"), join(root, "config/format-adapters.yaml"),
+    join(root, "config/initial-master-selection.yaml"), join(root, "config/monitoring.yaml"),
+    join(root, "config/sources.yaml"), join(root, "data/monitoring/semantic-baseline.json"),
+    join(root, "data/reconciliation/national-burden-ratio-mapping.yaml"),
+    join(root, "data/reconciliation/national-burden-ratio.csv"), join(root, "data/revenue/actuals.csv")
+  ]);
+  for (const path of ["data/burdens/consumption-tax.yaml", "data/burdens/initial-master.json", "data/candidates/local-taxes.yaml", "data/candidates/national-taxes.yaml", "data/candidates/public-burdens-government-additions.yaml", "data/candidates/public-burdens-question-39.yaml", "data/changes/consumption-tax-2019-rate.yaml", "data/events/consumption-tax-2019-application-started.yaml", "data/phases/consumption-tax.yaml"]) validated.add(join(root, path));
+  assert.deepEqual(await validatePersistedFileCoverage(root, validated), []);
+});
+
+test("an unregistered persisted file cannot bypass schema validation", async () => {
+  const root = await mkdtemp(join(tmpdir(), "repository-consistency-"));
+  for (const path of ["config", "data/burdens", "data/candidates", "data/changes", "data/events", "data/phases", "data/monitoring", "data/reconciliation", "data/revenue"]) await mkdir(join(root, path), { recursive: true });
+  await writeFile(join(root, "data/burdens/unmapped.csv"), "tax_id\nexample\n");
+  const errors = await validatePersistedFileCoverage(root, new Set());
+  assert.ok(errors.includes("data/burdens/unmapped.csv: no repository schema validation route"));
+});
+
+test("source and semantic baseline tax IDs must reference canonical burdens", () => {
+  const errors = validateIntegrity({
+    burdens: [], candidates: [], changes: [], events: [], phases: [], revenues: [], mappings: [],
+    sources: [{ source_id: "sample-source", monitoring_tax_ids: ["missing-tax"] }],
+    semanticBaselines: [{ records: [{ tax_id: "missing-baseline-tax" }] }]
+  });
+  assert.ok(errors.includes("sample-source.monitoring_tax_ids: unknown reference missing-tax"));
+  assert.ok(errors.includes("missing-baseline-tax.semantic_baseline.tax_id: unknown reference missing-baseline-tax"));
+});


### PR DESCRIPTION
Closes #82

## 概要

`data/`と`schemas/`、および設定・生成物・横断参照・scripts・workflow・文書の整合性を監査しました。既存の事実値やデータにSchema不適合はありませんでしたが、検証経路に2種類の不足があったため補強しています。

## 変更内容

- `data/`・`config/`の全永続ファイルがSchema検証経路を通ることを機械検査
- 未登録ファイルを`npm run validate`でfail closed
- sourceの`monitoring_tax_ids`からburdenへの参照検査を追加
- semantic baselineの`tax_id`からburdenへの参照検査を追加
- 回帰テストと監査記録を追加
- architecture inventoryを再生成

## 受け入れ条件

- [x] 全永続ファイルとSchema検証経路の対応を確認
- [x] 全データが対応Schemaへ適合
- [x] 未検証の永続データ形式なし
- [x] 横断ID、生成物、件数、分類に不一致なし
- [x] scripts、workflows、tests、文書の主要パス・コマンドを確認
- [x] 検出事項、判断、回帰テストを記録
- [x] 必須検証コマンドが成功

## 検証結果

- `npm test`: 149件成功、失敗0件
- `npm run validate`: 194ファイル、循環依存0件
- `npm run generate:check`: 6配布物および119候補に差分なし
- `npm run monitoring:check`: 112 targets、差分なし
- `npm run inventory:check`: 112 targets、10 batches、差分なし
- `npm run audit:coverage`: 112/112、errors 0

## 根拠URL

事実値・制度データ・巡回URLは変更していないため、新しい外部根拠URLはありません。既存データの`source_url`と`verified_at`を保持しています。

## 旧値・新値

- 旧: 新しい永続ファイルがvalidatorへ登録されなくても見逃し得る
- 新: `data/`・`config/`の未検証ファイルを検出して失敗
- 旧: sourceおよびsemantic baselineの`tax_id`を共通参照検査で直接確認しない
- 新: canonical burdenへの参照を必須化

## 影響範囲

validationと監査文書・テストのみ。税率、制度状態、日付、金額、URL、既存ID、workflow本数は変更していません。

## 不確実な点

なし。公式根拠を要する事実値変更は行っていません。